### PR TITLE
[Fix & Lint & Tweak] Some changes I like

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -111,10 +111,14 @@ export const configSchema: any = Schema.object({
       .default(["<|endoftext|>"])
       .role('table')
       .description("自定义停止词"),
-    OtherParameters: Schema.array(Schema.string())
-      .default(["do_sample: true", "grammar_string: \"\""])
-      .role('table')
-      .description("自定义请求体中的其他参数，例如dry_base: 1"),
+    BotSentencePostProcess: Schema.array(Schema.object({
+      replacethis: Schema.string().description("需要替换的文本"),
+      tothis: Schema.string().description("替换为的文本"),
+    })).default([{ replacethis: "。$", tothis: "" }]).role('table').description("Bot 生成的句子后处理，用于替换文本。每行一个替换规则，从上往下依次替换，支持正则表达式"),
+    OtherParameters: Schema.array(Schema.object({
+      key: Schema.string().description("键名"),
+      value: Schema.string().description("键值"),
+    })).default([{ key: "do_sample", value: "true" }, { key: "grammar_string", value: "root   ::= object\nobject ::= \"{\\n\\\"status\\\": \" status-value \",\\n\\\"logic\\\": \" logic-value \",\\n\\\"replyToID\\\": \" reply-value \",\\n\\\"select\\\": \" select-value \",\\n\\\"check\\\": \" check-value \",\\n\\\"finReply\\\": \" finReply-value \",\\n\\\"execute\\\": \" execute-value \"\\n}\"\nstring ::= \"\\\"\" ([^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt])* \"\\\"\"\nnumber ::= \"-\"? [0-9]+\nban-time ::= [1-9][0-9]{1,3} | [1-4][0-3][0-1][0-9][0-9]\nstatus-value  ::= \"\\\"success\\\"\" | \"\\\"skip\\\"\"\nlogic-value   ::= string | \"\\\"\\\"\"\nreply-value   ::= number | \"\\\"\\\"\"\nselect-value  ::= \"-1\"\ncheck-value   ::= \"\\\"\\\"\"\nfinReply-value::= string\nexecute-value ::= \"[\"( execute-cmds (\", \" execute-cmds )* )? \"]\"\nexecute-cmds  ::= delmsg | ban | reaction\ndelmsg        ::= \"\\\"delmsg \" number \"\\\"\"\nban           ::= \"\\\"ban \" number \" \" ban-time \"\\\"\"\nreaction      ::= \"\\\"reaction-create \" number \" \" number \"\\\"\""}]).role('table').description("自定义请求体中的其他参数，例如dry_base: 1。\n提示：直接将gbnf内容作为grammar_string的值粘贴至此时，换行符会被转换成空格，需要手动替换为\\n后方可生效"),
   }).description("API 参数"),
 
 	Verifier: Schema.intersect([

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,10 +111,6 @@ export const configSchema: any = Schema.object({
       .default(["<|endoftext|>"])
       .role('table')
       .description("自定义停止词"),
-    BotSentencePostProcess: Schema.array(Schema.object({
-      replacethis: Schema.string().description("需要替换的文本"),
-      tothis: Schema.string().description("替换为的文本"),
-    })).default([{ replacethis: "。$", tothis: "" }]).role('table').description("Bot 生成的句子后处理，用于替换文本。每行一个替换规则，从上往下依次替换，支持正则表达式"),
     OtherParameters: Schema.array(Schema.object({
       key: Schema.string().description("键名"),
       value: Schema.string().description("键值"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ export function apply(ctx: Context, config: Config) {
 
         if (config.Debug.LogicRedirect.Enabled) {
             const template = `回复于 ${groupId} 的消息已生成，来自 API ${curAPI}:
-内容: ${(handledRes.LLMResponse.finReply ? handledRes.LLMResponse.finReply : handledRes.LLMResponse.reply)}
+内容: ${(handledRes.LLMResponse.finReply ? handledRes.LLMResponse.finReply : handledRes.LLMResponse.replyToID)}
 ---
 逻辑: ${handledRes.LLMResponse.logic}
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export interface Config {
       FrequencyPenalty: number;
       PresencePenalty: number;
       Stop: string[];
-      OtherParameters: string[];
+      OtherParameters: any;
     };
     Bot: {
         PromptFileUrl: any;
@@ -245,7 +245,7 @@ export function apply(ctx: Context, config: Config) {
         sendQueue.updateSendQueue(
             groupId,
             config.Bot.BotName,
-			0,
+			      0,
             finalRes,
             0,
             config.Group.Filter

--- a/src/utils/api-adapter.ts
+++ b/src/utils/api-adapter.ts
@@ -12,18 +12,20 @@ export async function run(
 ): Promise<any> {
   let url: string, requestBody: any;
 
-  // 解析其他参数
-  const otherParams = {};
-  if (parameters.OtherParameters) {
-    parameters.OtherParameters.forEach((param: string) => {
-      const [key, value] = param.split(':').map(s => s.trim());
-      // 转换 value 为适当的类型
-      otherParams[key] = value === 'true' ? true :
-                        value === 'false' ? false :
-                        !isNaN(value as any) ? Number(value) :
-                        value;
-    });
-  }
+// 解析其他参数
+const otherParams = {};
+if (parameters.OtherParameters) {
+  parameters.OtherParameters.forEach((param: { key: string, value: string }) => {
+    const key = param.key.trim();
+    const value = param.value.trim();
+
+    // 转换 value 为适当的类型
+    otherParams[key] = value === 'true' ? true :
+                       value === 'false' ? false :
+                       !isNaN(value as any) ? Number(value) :
+                       value;
+  });
+}
 
   switch (APIType) {
     case "OpenAI": {

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -5,9 +5,9 @@ export function replaceTags(str: string): string {
   const videoRegex = /<video.*?\/>/g
   const audioRegex = /<audio.*?\/>/g
   let finalString: string = str;
-  finalString = finalString.replace(imgRegex, finalString);
-  finalString = finalString.replace(videoRegex, finalString);
-  finalString = finalString.replace(audioRegex, finalString);
+  finalString = finalString.replace(imgRegex, "[图片]");
+  finalString = finalString.replace(videoRegex, "[视频]");
+  finalString = finalString.replace(audioRegex, "[音频]");
   return finalString;
 }
 

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -63,10 +63,10 @@ export function handleResponse(
   if (!AllowErrorFormat) {
     finalResponse += LLMResponse.finReply
       ? LLMResponse.finReply
-      : LLMResponse.reply;
+      : LLMResponse.replyToID;
   } else {
     if (LLMResponse.finReply) finalResponse += LLMResponse.finReply;
-    else if (LLMResponse.reply) finalResponse += LLMResponse.reply;
+    else if (LLMResponse.replyToID) finalResponse += LLMResponse.replyToID;
     else if (LLMResponse.msg) finalResponse += LLMResponse.msg;
     else throw new Error(`LLM provides unexpected response: ${res}`);
   }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -55,11 +55,14 @@ export async function genSysPrompt(
   curGroupDescription: string,
   curGroupName: string
 ): Promise<string> {
-  // 获取当前日期
+  // 获取当前日期与时间
   const currentDate = new Date();
   const curYear: number = currentDate.getFullYear();
   const curMonth: number = currentDate.getMonth() + 1;
   const curDate: number = currentDate.getDate();
+  const curHour: number = currentDate.getHours();
+  const curMinute: number = currentDate.getMinutes();
+  const curSecond: number = currentDate.getSeconds();
 
   let content = fs.readFileSync(
     getFileNameFromUrl(config.Bot.PromptFileUrl[config.Bot.PromptFileSelected]),
@@ -94,6 +97,9 @@ export async function genSysPrompt(
   content = content.replaceAll("${curYear}", curYear.toString());
   content = content.replaceAll("${curMonth}", curMonth.toString());
   content = content.replaceAll("${curDate}", curDate.toString());
+  content = content.replaceAll("${curHour}", curHour.toString());
+  content = content.replaceAll("${curMinute}", curMinute.toString());
+  content = content.replaceAll("${curSecond}", curSecond.toString());
 
   content = content.replaceAll("${curGroupDescription}", curGroupDescription);
   content = content.replaceAll("${curGroupName}", curGroupName);

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,13 +1,22 @@
 import fs from "fs";
 import https from "https";
-import { Context } from "koishi";
+import { Context, is } from "koishi";
 import { promisify } from "util";
 
 export function getFileNameFromUrl(url: string): string {
-  const parsedUrl = new URL(url);
-  const filePath = parsedUrl.pathname;
-  const fileName = filePath.substring(filePath.lastIndexOf("/") + 1);
-  return fileName;
+  try {
+    const parsedUrl = new URL(url);
+    const filePath = parsedUrl.pathname;
+    return filePath.substring(filePath.lastIndexOf("/") + 1);
+  } catch (error) {
+    // 根据文档，此时认为用户输入的是文件名
+    if (error instanceof TypeError && error.message.includes("Invalid URL")) {
+      return url;
+    } else {
+      // 重新抛出非 "Invalid URL" 的错误
+      throw error;
+    }
+  }
 }
 
 // 将 fs.exists 转换为 Promise 版本
@@ -23,31 +32,54 @@ export async function ensurePromptFileExists(
 
   const fileExists = await exists(filePath);
 
-  if (fileExists && !forceLoad) {
-    if (debug) ctx.logger.info("Prompt file already exists.");
-    return;
+  // 检查 URL 是否合法
+  let isURL = true;
+  try {
+    new URL(url);
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes("Invalid URL")) {
+      isURL = false;
+    } else {
+      // 重新抛出非 "Invalid URL" 的错误
+      throw error;
+    }
   }
 
-  // 文件不存在，从 URL 下载
-  if (debug && !forceLoad)
-    ctx.logger.info("Prompt file not found, downloading...");
-  const file = fs.createWriteStream(filePath);
-  const request = https.get(url, (response) => {
-    response.pipe(file);
-    file.on("finish", () => {
-      file.close();
-      if (debug) ctx.logger.info("Successfully downloaded prompt file.");
+  // 下载文件小助手
+  const downloadFile = (url, filePath, debug, ctx) => {
+    const file = fs.createWriteStream(filePath);
+    const request = https.get(url, (response) => {
+      response.pipe(file);
+      file.on("finish", () => {
+        file.close();
+        if (debug) ctx.logger.info("Successfully downloaded prompt file.");
+      });
     });
-  });
 
-  request.on("error", (err) => {
-    fs.unlink(filePath, () => {});
-    if (debug)
-      ctx.logger.error(
-        "An error occurred while downloading prompt file: ",
-        err.message.toString()
-      );
-  });
+    request.on("error", (err) => {
+      fs.unlink(filePath, () => {});
+      if (debug)
+        ctx.logger.error("An error occurred while downloading prompt file: ", err.message.toString());
+    });
+  };
+
+  // 文件存在
+  if (fileExists) {
+    // 如果需要强制加载且URL合法，下载文件
+    if (forceLoad && isURL) {
+      downloadFile(url, filePath, debug, ctx);
+    } else {
+      if (debug) ctx.logger.info("Prompt file already exists.");
+    }
+  } else {
+    // 文件不存在且URL合法，下载文件
+    if (isURL) {
+      if (debug) ctx.logger.info("Prompt file not found, downloading ...");
+      downloadFile(url, filePath, debug, ctx);
+    } else {
+      if (debug) ctx.logger.error("Prompt file not found.");
+    }
+  }
 }
 
 export async function genSysPrompt(

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import https from "https";
-import { Context, is } from "koishi";
+import { Context } from "koishi";
 import { promisify } from "util";
 
 export function getFileNameFromUrl(url: string): string {

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -23,7 +23,7 @@ export class SendQueue {
   updateSendQueue(
     group: string,
     sender: string,
-	sender_id:　any,
+	  sender_id: any,
     content: string,
     id: any,
     FilterList: any


### PR DESCRIPTION
>在 机器人设定 配置中，我们提供了 `Bot.PromptFileURL` 列表。对于列表的每一项，你只需要填写 Prompt 文件的下载链接或者**本地文件名称**即可。

什么？我按照[文档](https://yesimbot.ccalliance.tech/docs/user/config/prompt.html)的说法，下载下来prompt文件放到了Koishi的运行目录，并在插件配置里正确填写了文件名，结果它给我报个TypeError: Invaild URL？

为了让傻傻的LLM更加容易明白生成的json中reply的意思，我把它改名成replyToID了，需要注意对应更新prompt文件。  

我还把可供llama.cpp使用的gbnf写成了自定义参数的默认值之一，这样如果你使用text-generation-webui开api来本地玩，这个gbnf可以保证LLM的回复符合Athena的胃口。  

既然已经获取了日期，为什么不一起把时间也一起获取呢？我把时间也加上了。

追加修复一个当图文混排时图片被替换成消息本身导致的消息文本部分重复的bug