### PR TITLE
[feat & fix & lint]解耦队列长度和第一次的触发条数

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	"koishi": {
 		"description": {
 			"zh": "让语言大模型机器人假装群友并和群友聊天！",
-			"en": "A Koishi plugin that allows LLM chat in your channel."
+			"en": "A Koishi plugin that allows LLM chat in your guild."
 		},
 		"browser": true,
 		"service": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,48 +1,48 @@
 import {
-	Schema
+  Schema
 } from "koishi";
 
 export const configSchema: any = Schema.object({
-	Group: Schema.object({
-		AllowedGroups: Schema.array(Schema.string())
-			.required()
-			.description("允许的群聊"),
-		SendQueueSize: Schema.number()
-			.default(20)
-			.description("Bot 接收的上下文数量（消息队列长度）"),
-		MaxPopNum: Schema.number()
-			.default(10)
-			.description("消息队列每次出队的最大数量"),
-		MinPopNum: Schema.number()
-			.default(1)
-			.description("消息队列每次出队的最小数量"),
-		AtReactPossiblilty: Schema.number()
-			.default(0.5)
-			.min(0).max(1).step(0.05)
-			.role('slider')
-			.description("立即回复 @ 消息的概率"),
-		Filter: Schema.array(Schema.string())
-			.default(["你是", "You are", "吧", "呢"])
-			.description("过滤的词汇（防止被调皮群友/机器人自己搞傻）"),
-	}).description("群聊设置"),
+  Group: Schema.object({
+    AllowedGroups: Schema.array(Schema.string())
+      .required()
+      .description("允许的群聊"),
+    SendQueueSize: Schema.number()
+      .default(20)
+      .description("Bot 接收的上下文数量（消息队列长度）"),
+    MaxPopNum: Schema.number()
+      .default(10)
+      .description("消息队列每次出队的最大数量"),
+    MinPopNum: Schema.number()
+      .default(1)
+      .description("消息队列每次出队的最小数量"),
+    AtReactPossiblilty: Schema.number()
+      .default(0.5)
+      .min(0).max(1).step(0.05)
+      .role('slider')
+      .description("立即回复 @ 消息的概率"),
+    Filter: Schema.array(Schema.string())
+      .default(["你是", "You are", "吧", "呢"])
+      .description("过滤的词汇（防止被调皮群友/机器人自己搞傻）"),
+  }).description("群聊设置"),
 
-	API: Schema.object({
-		APIList: Schema.array(Schema.object({
-			APIType: Schema.union(["OpenAI", "Cloudflare", "Custom URL"]).default("OpenAI").description(
-				"API 类型"
-			),
-			BaseURL: Schema.string()
-				.default("https://api.openai.com/")
-				.description("API 基础 URL, 设置为“Custom URL”需要填写完整的 URL"),
-			UID: Schema.string()
-				.default("若非 Cloudflare 可不填")
-				.description("Cloudflare UID"),
-			APIKey: Schema.string().required().description("你的 API 令牌"),
-			AIModel: Schema.string()
-				.default("@cf/meta/llama-3-8b-instruct")
-				.description("模型 ID"),
-		})).description("单个 LLM API 配置，可配置多个 API 进行负载均衡。"),
-	}).description("LLM API 相关配置"),
+  API: Schema.object({
+    APIList: Schema.array(Schema.object({
+      APIType: Schema.union(["OpenAI", "Cloudflare", "Custom URL"]).default("OpenAI").description(
+        "API 类型"
+      ),
+      BaseURL: Schema.string()
+        .default("https://api.openai.com/")
+        .description("API 基础 URL, 设置为“Custom URL”需要填写完整的 URL"),
+      UID: Schema.string()
+        .default("若非 Cloudflare 可不填")
+        .description("Cloudflare UID"),
+      APIKey: Schema.string().required().description("你的 API 令牌"),
+      AIModel: Schema.string()
+        .default("@cf/meta/llama-3-8b-instruct")
+        .description("模型 ID"),
+    })).description("单个 LLM API 配置，可配置多个 API 进行负载均衡。"),
+  }).description("LLM API 相关配置"),
 
   Parameters: Schema.object({
     Temperature: Schema.number()
@@ -114,7 +114,7 @@ export const configSchema: any = Schema.object({
     OtherParameters: Schema.array(Schema.object({
       key: Schema.string().description("键名"),
       value: Schema.string().description("键值"),
-    })).default([{ key: "do_sample", value: "true" }, { key: "grammar_string", value: "root   ::= object\nobject ::= \"{\\n\\\"status\\\": \" status-value \",\\n\\\"logic\\\": \" logic-value \",\\n\\\"replyToID\\\": \" reply-value \",\\n\\\"select\\\": \" select-value \",\\n\\\"check\\\": \" check-value \",\\n\\\"finReply\\\": \" finReply-value \",\\n\\\"execute\\\": \" execute-value \"\\n}\"\nstring ::= \"\\\"\" ([^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt])* \"\\\"\"\nnumber ::= \"-\"? [0-9]+\nban-time ::= [1-9][0-9]{1,3} | [1-4][0-3][0-1][0-9][0-9]\nstatus-value  ::= \"\\\"success\\\"\" | \"\\\"skip\\\"\"\nlogic-value   ::= string | \"\\\"\\\"\"\nreply-value   ::= number | \"\\\"\\\"\"\nselect-value  ::= \"-1\"\ncheck-value   ::= \"\\\"\\\"\"\nfinReply-value::= string\nexecute-value ::= \"[\"( execute-cmds (\", \" execute-cmds )* )? \"]\"\nexecute-cmds  ::= delmsg | ban | reaction\ndelmsg        ::= \"\\\"delmsg \" number \"\\\"\"\nban           ::= \"\\\"ban \" number \" \" ban-time \"\\\"\"\nreaction      ::= \"\\\"reaction-create \" number \" \" number \"\\\"\""}]).role('table').description("自定义请求体中的其他参数，例如dry_base: 1。\n提示：直接将gbnf内容作为grammar_string的值粘贴至此时，换行符会被转换成空格，需要手动替换为\\n后方可生效"),
+    })).default([{ key: "do_sample", value: "true" }, { key: "grammar_string", value: "root   ::= object\nobject ::= \"{\\n\\\"status\\\": \" status-value \",\\n\\\"logic\\\": \" logic-value \",\\n\\\"select\\\": \" select-value \",\\n\\\"reply\\\": \" reply-value \",\\n\\\"check\\\": \" check-value \",\\n\\\"finReply\\\": \" finReply-value \",\\n\\\"execute\\\": \" execute-value \"\\n}\"\nstring ::= \"\\\"\" ([^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt])* \"\\\"\"\nnumber ::= [0-9]+\nban-time ::= [1-9][0-9]{1,3} | [1-4][0-3][0-1][0-9][0-9]\nstatus-value  ::= \"\\\"success\\\"\" | \"\\\"skip\\\"\"\nlogic-value   ::= string | \"\\\"\\\"\"\nselect-value  ::= number | \"-1\"\nreply-value   ::= string\ncheck-value   ::= \"\\\"\\\"\"\nfinReply-value::= string\nexecute-value ::= \"[\"( execute-cmds (\", \" execute-cmds )* )? \"]\"\nexecute-cmds  ::= delmsg | ban | reaction\ndelmsg        ::= \"\\\"delmsg \" number \"\\\"\"\nban           ::= \"\\\"ban \" number \" \" ban-time \"\\\"\"\nreaction      ::= \"\\\"reaction-create \" number \" \" number \"\\\"\"" }]).role('table').description("自定义请求体中的其他参数，例如dry_base: 1。\n提示：直接将gbnf内容作为grammar_string的值粘贴至此时，换行符会被转换成空格，需要手动替换为\\n后方可生效"),
   }).description("API 参数"),
 
   Embedding: Schema.object({
@@ -127,131 +127,131 @@ export const configSchema: any = Schema.object({
     })).description("单个 Embedding 模型配置，可配置多个 API 进行负载均衡。"),
   }).description("Embedding 模型相关配置，可用于存储BOT的记忆"),
 
-	Verifier: Schema.intersect([
-		Schema.object({
-			Enabled: Schema.boolean().default(false),
-		}).description('是否启用相似度验证'),
-		Schema.union([
-			Schema.object({
-				Enabled: Schema.const(true).required(),
-				API: Schema.object({
-					APIType: Schema.union(["OpenAI", "Cloudflare", "Custom URL"])
-						.default("OpenAI")
-						.description("验证器 API 类型"),
-					BaseURL: Schema.string()
-						.default("https://api.openai.com/")
-						.description("验证器 API 基础 URL"),
-					UID: Schema.string()
-						.default("")
-						.description("验证器 Cloudflare UID（如果适用）"),
-					APIKey: Schema.string()
-						.default("sk-xxxxxxx")
-						.description("验证器 API 令牌"),
-					AIModel: Schema.string()
-						.default("gpt-3.5-turbo")
-						.description("验证器使用的模型，可以使用embedding模型"),
-				}).description("验证器 API 配置"),
-				SimilarityThreshold: Schema.number()
-					.default(0.75)
-					.min(0)
-					.max(1)
-					.step(0.05)
-					.role('slider')
-					.description("相似度阈值，超过此值的回复将被过滤"),
-            }),
-            Schema.object({})
-		])
-    ]),
+  Verifier: Schema.intersect([
+    Schema.object({
+      Enabled: Schema.boolean().default(false),
+    }).description('是否启用相似度验证'),
+    Schema.union([
+      Schema.object({
+        Enabled: Schema.const(true).required(),
+        API: Schema.object({
+          APIType: Schema.union(["OpenAI", "Cloudflare", "Custom URL"])
+            .default("OpenAI")
+            .description("验证器 API 类型"),
+          BaseURL: Schema.string()
+            .default("https://api.openai.com/")
+            .description("验证器 API 基础 URL"),
+          UID: Schema.string()
+            .default("")
+            .description("验证器 Cloudflare UID（如果适用）"),
+          APIKey: Schema.string()
+            .default("sk-xxxxxxx")
+            .description("验证器 API 令牌"),
+          AIModel: Schema.string()
+            .default("gpt-3.5-turbo")
+            .description("验证器使用的模型，可以使用embedding模型"),
+        }).description("验证器 API 配置"),
+        SimilarityThreshold: Schema.number()
+          .default(0.75)
+          .min(0)
+          .max(1)
+          .step(0.05)
+          .role('slider')
+          .description("相似度阈值，超过此值的回复将被过滤"),
+      }),
+      Schema.object({})
+    ])
+  ]),
 
-    // 保留备用
-    // Memory: Schema.intersect([
-    //     Schema.object({
-    //         Enabled: Schema.boolean().default(false),
-    //     }).description('是否启用记忆中枢'),
-    //     Schema.union([
-    //         Schema.object({
-    //             Enabled: Schema.const(true).required(),
-    //             API: Schema.object({
-    //                 APIType: Schema.union(["OpenAI", "Cloudflare", "Custom URL"])
-    //                     .default("OpenAI")
-    //                     .description("记忆中枢 API 类型"),
-    //                 BaseURL: Schema.string()
-    //                     .default("https://api.openai.com/")
-    //                     .description("记忆中枢 API 基础 URL"),
-    //                 UID: Schema.string()
-    //                     .default("")
-    //                     .description("记忆中枢 Cloudflare UID（如果适用）"),
-    //                 APIKey: Schema.string()
-    //                     .default("sk-xxxxxxx")
-    //                     .description("记忆中枢 API 令牌"),
-    //                 AIModel: Schema.string()
-    //                     .default("gpt-3.5-turbo")
-    //                     .description("记忆中枢使用的模型"),
-    //             }).description("记忆中枢 API 配置"),
-    //         }),
-    //     ])
-    // ]),
+  // 保留备用
+  // Memory: Schema.intersect([
+  //     Schema.object({
+  //         Enabled: Schema.boolean().default(false),
+  //     }).description('是否启用记忆中枢'),
+  //     Schema.union([
+  //         Schema.object({
+  //             Enabled: Schema.const(true).required(),
+  //             API: Schema.object({
+  //                 APIType: Schema.union(["OpenAI", "Cloudflare", "Custom URL"])
+  //                     .default("OpenAI")
+  //                     .description("记忆中枢 API 类型"),
+  //                 BaseURL: Schema.string()
+  //                     .default("https://api.openai.com/")
+  //                     .description("记忆中枢 API 基础 URL"),
+  //                 UID: Schema.string()
+  //                     .default("")
+  //                     .description("记忆中枢 Cloudflare UID（如果适用）"),
+  //                 APIKey: Schema.string()
+  //                     .default("sk-xxxxxxx")
+  //                     .description("记忆中枢 API 令牌"),
+  //                 AIModel: Schema.string()
+  //                     .default("gpt-3.5-turbo")
+  //                     .description("记忆中枢使用的模型"),
+  //             }).description("记忆中枢 API 配置"),
+  //         }),
+  //     ])
+  // ]),
 
-	Bot: Schema.object({
-		PromptFileUrl: Schema.array(Schema.string())
-			.default([
-				"https://fastly.jsdelivr.net/gh/HydroGest/promptHosting@main/src/prompt-legacy.mdt",
-				"https://fastly.jsdelivr.net/gh/HydroGest/promptHosting@main/src/prompt-next.mdt",
-				"https://fastly.jsdelivr.net/gh/HydroGest/promptHosting@main/src/prompt-next-short.mdt",
-			])
-			.description("Prompt 文件下载链接。一般情况下不需要修改。"),
-		PromptFileSelected: Schema.number()
-			.default(2)
-			.description("Prompt 文件编号，从 0 开始。请阅读 readme 再修改!"),
-		BotName: Schema.string().default("Athena").description("Bot 的名字，最好是 Bot 的用户名"),
-		WhoAmI: Schema.string()
-			.default("一个普通的群友")
-			.description("Bot 的简要设定"),
-		BotHometown: Schema.string().default("广州").description("Bot 的家乡"),
-		SendDirectly: Schema.boolean()
-			.default(false)
-			.description("运行时屏蔽其他指令"),
-		BotYearold: Schema.string().default("16").description("Bot 的年龄"),
-		BotPersonality: Schema.string()
-			.default("外向/有爱")
-			.description("Bot 性格"),
-		BotGender: Schema.string().default("女").description("Bot 的性别"),
-		BotHabbits: Schema.string().default("").description("Bot 的爱好"),
-		BotBackground: Schema.string()
-			.default("高中女生")
-			.description("Bot 的背景"),
+  Bot: Schema.object({
+    PromptFileUrl: Schema.array(Schema.string())
+      .default([
+        "https://fastly.jsdelivr.net/gh/HydroGest/promptHosting@main/src/prompt-legacy.mdt",
+        "https://fastly.jsdelivr.net/gh/HydroGest/promptHosting@main/src/prompt-next.mdt",
+        "https://fastly.jsdelivr.net/gh/HydroGest/promptHosting@main/src/prompt-next-short.mdt",
+      ])
+      .description("Prompt 文件下载链接。一般情况下不需要修改。"),
+    PromptFileSelected: Schema.number()
+      .default(2)
+      .description("Prompt 文件编号，从 0 开始。请阅读 readme 再修改!"),
+    BotName: Schema.string().default("Athena").description("Bot 的名字，最好是 Bot 的用户名"),
+    WhoAmI: Schema.string()
+      .default("一个普通的群友")
+      .description("Bot 的简要设定"),
+    BotHometown: Schema.string().default("广州").description("Bot 的家乡"),
+    SendDirectly: Schema.boolean()
+      .default(false)
+      .description("运行时屏蔽其他指令"),
+    BotYearold: Schema.string().default("16").description("Bot 的年龄"),
+    BotPersonality: Schema.string()
+      .default("外向/有爱")
+      .description("Bot 性格"),
+    BotGender: Schema.string().default("女").description("Bot 的性别"),
+    BotHabbits: Schema.string().default("").description("Bot 的爱好"),
+    BotBackground: Schema.string()
+      .default("高中女生")
+      .description("Bot 的背景"),
     BotSentencePostProcess: Schema.array(Schema.object({
       replacethis: Schema.string().description("需要替换的文本"),
       tothis: Schema.string().description("替换为的文本"),
     })).default([{ replacethis: "。$", tothis: "" }]).role('table').description("Bot 生成的句子后处理，用于替换文本。每行一个替换规则，从上往下依次替换，支持正则表达式"),
-		CuteMode: Schema.boolean().default(false).description("原神模式（迫真"),
-	}).description("机器人设定"),
-    Debug: Schema.object({
-        LogicRedirect: Schema.intersect([
-            Schema.object({
-                Enabled: Schema.boolean().default(false).description('是否开启逻辑重定向'),
-            }),
-            Schema.union([
-                Schema.object({
-                    Enabled: Schema.const(true).required(),
-                    Target: Schema.string()
-                        .default("")
-                        .description("将 Bot 的发言逻辑重定向到群组"),
-                }),
-                Schema.object({}),
-            ])
-        ]),
-		DebugAsInfo: Schema.boolean()
-			.default(false)
-			.description("在控制台显示 Debug 消息"),
-		DisableGroupFilter: Schema.boolean()
-			.default(false)
-			.description("禁用聊群筛选器，接收并回复所有群的消息"),
-		UpdatePromptOnLoad: Schema.boolean()
-			.default(true)
-			.description("每次启动时尝试更新 Prompt 文件"),
-		AllowErrorFormat: Schema.boolean()
-			.default(false)
-			.description("兼容几种较为常见的大模型错误输出格式"),
-	}).description("调试工具"),
+    CuteMode: Schema.boolean().default(false).description("原神模式（迫真"),
+  }).description("机器人设定"),
+  Debug: Schema.object({
+    LogicRedirect: Schema.intersect([
+      Schema.object({
+        Enabled: Schema.boolean().default(false).description('是否开启逻辑重定向'),
+      }),
+      Schema.union([
+        Schema.object({
+          Enabled: Schema.const(true).required(),
+          Target: Schema.string()
+            .default("")
+            .description("将 Bot 的发言逻辑重定向到群组"),
+        }),
+        Schema.object({}),
+      ])
+    ]),
+    DebugAsInfo: Schema.boolean()
+      .default(false)
+      .description("在控制台显示 Debug 消息"),
+    DisableGroupFilter: Schema.boolean()
+      .default(false)
+      .description("禁用聊群筛选器，接收并回复所有群的消息"),
+    UpdatePromptOnLoad: Schema.boolean()
+      .default(true)
+      .description("每次启动时尝试更新 Prompt 文件"),
+    AllowErrorFormat: Schema.boolean()
+      .default(false)
+      .description("兼容几种较为常见的大模型错误输出格式"),
+  }).description("调试工具"),
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,14 +8,17 @@ export const configSchema: any = Schema.object({
       .required()
       .description("允许的群聊"),
     SendQueueSize: Schema.number()
-      .default(20)
-      .description("Bot 接收的上下文数量（消息队列长度）"),
+      .default(20).min(1)
+      .description("Bot 接收的上下文数量（消息队列最大长度）"),
+    TriggerCount: Schema.number()
+      .default(3).min(1)
+      .description("Bot 开始回复消息的初始触发计数"),
     MaxPopNum: Schema.number()
-      .default(10)
-      .description("消息队列每次出队的最大数量"),
+      .default(10).min(1)
+      .description("Bot 两次回复之间的最大消息数"),
     MinPopNum: Schema.number()
-      .default(1)
-      .description("消息队列每次出队的最小数量"),
+      .default(1).min(1)
+      .description("Bot 两次回复之间的最小消息数"),
     AtReactPossiblilty: Schema.number()
       .default(0.5)
       .min(0).max(1).step(0.05)

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,61 +20,61 @@ export const usage = `\"Yes! I'm Bot!\" 是一个能让你的机器人激活灵�
 `;
 
 export interface Config {
-    Group: {
-        AllowedGroups: any;
-        SendQueueSize: number;
-        MaxPopNum: number;
-        MinPopNum: number;
-        AtReactPossiblilty: number;
-        Filter: any;
-    };
-    API: {
-        APIList: {
-            APIType: any;
-            BaseURL: string;
-            UID: string;
-            APIKey: string;
-            AIModel: string;
-        }[];
-    };
-    Parameters: {
-      Temperature: number;
-      MaxTokens: number;
-      TopK: number;
-      TopP: number;
-      TypicalP: number;
-      MinP: number;
-      TopA: number;
-      FrequencyPenalty: number;
-      PresencePenalty: number;
-      Stop: string[];
-      OtherParameters: any;
-    };
-    Bot: {
-        PromptFileUrl: any;
-        PromptFileSelected: number;
-        BotName: string;
-        WhoAmI: string;
-        BotHometown: string;
-        SendDirectly: boolean;
-        BotYearold: string;
-        BotPersonality: string;
-        BotGender: string;
-        BotHabbits: string;
-        BotBackground: string;
-        CuteMode: boolean;
-        BotSentencePostProcess: any;
-    };
-    Debug: {
-        LogicRedirect: {
-            Enabled: boolean;
-            Target: string;
-        }
-        DebugAsInfo: boolean;
-        DisableGroupFilter: boolean;
-        UpdatePromptOnLoad: boolean;
-        AllowErrorFormat: boolean;
-    };
+  Group: {
+    AllowedGroups: any;
+    SendQueueSize: number;
+    MaxPopNum: number;
+    MinPopNum: number;
+    AtReactPossiblilty: number;
+    Filter: any;
+  };
+  API: {
+    APIList: {
+      APIType: any;
+      BaseURL: string;
+      UID: string;
+      APIKey: string;
+      AIModel: string;
+    }[];
+  };
+  Parameters: {
+    Temperature: number;
+    MaxTokens: number;
+    TopK: number;
+    TopP: number;
+    TypicalP: number;
+    MinP: number;
+    TopA: number;
+    FrequencyPenalty: number;
+    PresencePenalty: number;
+    Stop: string[];
+    OtherParameters: any;
+  };
+  Bot: {
+    PromptFileUrl: any;
+    PromptFileSelected: number;
+    BotName: string;
+    WhoAmI: string;
+    BotHometown: string;
+    SendDirectly: boolean;
+    BotYearold: string;
+    BotPersonality: string;
+    BotGender: string;
+    BotHabbits: string;
+    BotBackground: string;
+    CuteMode: boolean;
+    BotSentencePostProcess: any;
+  };
+  Debug: {
+    LogicRedirect: {
+      Enabled: boolean;
+      Target: string;
+    }
+    DebugAsInfo: boolean;
+    DisableGroupFilter: boolean;
+    UpdatePromptOnLoad: boolean;
+    AllowErrorFormat: boolean;
+  };
 }
 
 export const Config: Schema<Config> = configSchema;
@@ -84,17 +84,17 @@ const sendQueue = new SendQueue();
 const responseVerifier = new ResponseVerifier();
 
 class APIStatus {
-    private currentStatus: number = 0;
+  private currentStatus: number = 0;
 
-    updateStatus(APILength): void {
-        this.currentStatus++;
-        if (this.currentStatus >= APILength) {
-            this.currentStatus = 0;
-        }
+  updateStatus(APILength): void {
+    this.currentStatus++;
+    if (this.currentStatus >= APILength) {
+      this.currentStatus = 0;
     }
-    getStatus(): number {
-        return this.currentStatus;
-    }
+  }
+  getStatus(): number {
+    return this.currentStatus;
+  }
 }
 
 const status = new APIStatus();
@@ -104,175 +104,179 @@ export const inject = {
 }
 
 export function apply(ctx: Context, config: Config) {
-    // 当应用启动时更新 Prompt
-    ctx.on("ready", async () => {
-        if (!config.Debug.UpdatePromptOnLoad) return;
-        ctx.logger.info("正在尝试更新 Prompt 文件...");
-        await ensurePromptFileExists(
-            config.Bot.PromptFileUrl[config.Bot.PromptFileSelected],
-            config.Debug.DebugAsInfo ? ctx : null,
-            true
-        );
-    });
+  // 当应用启动时更新 Prompt
+  ctx.on("ready", async () => {
+    if (!config.Debug.UpdatePromptOnLoad) return;
+    ctx.logger.info("正在尝试更新 Prompt 文件...");
+    await ensurePromptFileExists(
+      config.Bot.PromptFileUrl[config.Bot.PromptFileSelected],
+      config.Debug.DebugAsInfo ? ctx : null,
+      true
+    );
+  });
 
-    ctx.middleware(async (session: any, next: Next) => {
-        const groupId: string = session.channelId;
+  ctx.middleware(async (session: any, next: Next) => {
+    const groupId: string = session.guildId;
+    if (!session.groupMemberList) {
+      session.groupMemberList = await session.bot.getGuildMemberList(session.guildId);
+    }
 
-        if (config.Debug.DebugAsInfo)
-            ctx.logger.info(`New message recieved, channelId = ${groupId}`);
+    if (config.Debug.DebugAsInfo)
+      ctx.logger.info(`New message recieved, guildId = ${groupId}`);
 
-        if (
-            !config.Group.AllowedGroups.includes(groupId) &&
-            !config.Debug.DisableGroupFilter
-        )
-            return next();
+    if (
+      !config.Group.AllowedGroups.includes(groupId) &&
+      !config.Debug.DisableGroupFilter
+    )
+      return next();
 
-        const userContent = await processUserContent(session);
+    const userContent = await processUserContent(session);
 
-        sendQueue.updateSendQueue(
-            groupId,
-            session.event.user.name,
-			session.event.user.id,
-            userContent,
-            session.messageId,
-            config.Group.Filter
-        );
+    sendQueue.updateSendQueue(
+      groupId,
+      userContent.name,
+      session.event.user.id,
+      userContent.content,
+      session.messageId,
+      config.Group.Filter
+    );
 
-        // 检测是否达到发送次数或被 at
-        // 返回 false 的条件：
-        // 发送队列已满 或者 用户消息提及机器人且随机条件命中：
-        if (
-            !sendQueue.checkQueueSize(groupId, config.Group.SendQueueSize) &&
-            !(
-                userContent.includes(`@${config.Bot.BotName}`) &&
-                Random.bool(config.Group.AtReactPossiblilty)
-            )
-        ) {
-            if (config.Debug.DebugAsInfo)
-                ctx.logger.info(sendQueue.getPrompt(groupId));
-            return next();
-        }
+    // 检测是否达到发送次数或被 at
+    // 返回 false 的条件：
+    // 发送队列已满 或者 用户消息提及机器人且随机条件命中。也就是说：
+    // 如果发送队列未满 (!isQueueFull)
+    // 并且消息没有提及机器人或者提及了机器人但随机条件未命中 (!(isAtMentioned && shouldReactToAt))
+    // 那么就会执行内部的代码，跳过这个中间件，不向api发送请求
+    const isQueueFull = sendQueue.checkQueueSize(groupId, config.Group.SendQueueSize);
+    const isAtMentioned = /<at id="${session.bot.selfId}".*?>/.test(session.content);
+    const shouldReactToAt = Random.bool(config.Group.AtReactPossiblilty);
 
-        await ensurePromptFileExists(
-            config.Bot.PromptFileUrl[config.Bot.PromptFileSelected],
-            config.Debug.DebugAsInfo ? ctx : null
-        );
+    if (!isQueueFull && !(isAtMentioned && shouldReactToAt)) {
+      if (config.Debug.DebugAsInfo)
+        ctx.logger.info(sendQueue.getPrompt(groupId));
+      return next();
+    }
 
-        if (config.Debug.DebugAsInfo)
-            ctx.logger.info(`Request sent, awaiting for response...`);
+    await ensurePromptFileExists(
+      config.Bot.PromptFileUrl[config.Bot.PromptFileSelected],
+      config.Debug.DebugAsInfo ? ctx : null
+    );
 
-        // 获取 Prompt
-        const SysPrompt: string = await genSysPrompt(
-            config,
-            session.event.channel.name,
-            session.event.channel.name
-        );
+    if (config.Debug.DebugAsInfo)
+      ctx.logger.info(`Request sent, awaiting for response...`);
 
-        // 消息队列出队
-        const chatData: string = sendQueue.getPrompt(groupId);
-        sendQueue.resetSendQueue(
-            groupId,
-            Random.int(config.Group.MinPopNum, config.Group.MaxPopNum)
-        );
+    // 获取 Prompt
+    const SysPrompt: string = await genSysPrompt(
+      config,
+      session.guildName
+    );
 
-        const curAPI = status.getStatus();
-        status.updateStatus(config.API.APIList.length);
+    // 消息队列出队
+    const chatData: string = sendQueue.getPrompt(groupId);
+    sendQueue.resetSendQueue(
+      groupId,
+      Random.int(config.Group.MinPopNum, config.Group.MaxPopNum)
+    );
 
-        if (config.Debug.DebugAsInfo)
-            ctx.logger.info(
-                `Using API ${curAPI}, BaseURL ${config.API.APIList[curAPI].BaseURL}.`
-            );
+    const curAPI = status.getStatus();
+    status.updateStatus(config.API.APIList.length);
 
-        // 获取回答
-        const { response, requestBody } = await runChatCompeletion(
-            config.API.APIList[curAPI].APIType,
-            config.API.APIList[curAPI].BaseURL,
-            config.API.APIList[curAPI].UID,
-            config.API.APIList[curAPI].APIKey,
-            config.API.APIList[curAPI].AIModel,
-            SysPrompt,
-            chatData,
-            config.Parameters
-        );
+    if (config.Debug.DebugAsInfo)
+      ctx.logger.info(
+        `Using API ${curAPI}, BaseURL ${config.API.APIList[curAPI].BaseURL}.`
+      );
 
-        if (config.Debug.DebugAsInfo)
-            ctx.logger.info(`Request body: ${JSON.stringify(requestBody, null, 2)}`);
+    // 获取回答
+    const { response, requestBody } = await runChatCompeletion(
+      config.API.APIList[curAPI].APIType,
+      config.API.APIList[curAPI].BaseURL,
+      config.API.APIList[curAPI].UID,
+      config.API.APIList[curAPI].APIKey,
+      config.API.APIList[curAPI].AIModel,
+      SysPrompt,
+      chatData,
+      config.Parameters
+    );
 
-        if (config.Debug.DebugAsInfo)
-            ctx.logger.info(JSON.stringify(response, null, 2));
+    if (config.Debug.DebugAsInfo)
+      ctx.logger.info(`Request body: ${JSON.stringify(requestBody, null, 2)}`);
 
-        const handledRes: {
-            res: string;
-            LLMResponse: any;
-            usage: any;
-        } = handleResponse(
-            config.API.APIList[curAPI].APIType,
-            response,
-            config.Debug.AllowErrorFormat
-        );
+    if (config.Debug.DebugAsInfo)
+      ctx.logger.info(JSON.stringify(response, null, 2));
 
-        const finalRes: string = handledRes.res;
+    const handledRes: {
+      res: string;
+      LLMResponse: any;
+      usage: any;
+    } = handleResponse(
+      config.API.APIList[curAPI].APIType,
+      response,
+      config.Debug.AllowErrorFormat,
+      session
+    );
 
-        if (config.Debug.LogicRedirect.Enabled) {
-            const template = `回复于 ${groupId} 的消息已生成，来自 API ${curAPI}:
-内容: ${(handledRes.LLMResponse.finReply ? handledRes.LLMResponse.finReply : handledRes.LLMResponse.replyToID)}
+    const finalRes: string = handledRes.res;
+
+    if (config.Debug.LogicRedirect.Enabled) {
+      const template = `回复于 ${groupId} 的消息已生成，来自 API ${curAPI}:
+内容: ${(handledRes.LLMResponse.finReply ? handledRes.LLMResponse.finReply : handledRes.LLMResponse.reply)}
 ---
 逻辑: ${handledRes.LLMResponse.logic}
 ---
 指令：${(handledRes.LLMResponse.execute ? handledRes.LLMResponse.execute : "无")}
 ---
 消耗: 输入 ${handledRes.usage["prompt_tokens"]}, 输出 ${handledRes.usage["completion_tokens"]}`;
-            await session.bot.sendMessage(config.Debug.LogicRedirect.Target, template);
-        }
+      await session.bot.sendMessage(config.Debug.LogicRedirect.Target, template);
+    }
 
-        responseVerifier.loadConfig(config);
+    responseVerifier.loadConfig(config);
 
-        const isAllowed = await responseVerifier.verifyResponse(finalRes);
+    const isAllowed = await responseVerifier.verifyResponse(finalRes);
 
-        if (!isAllowed) {
-            if (config.Debug.DebugAsInfo) {
-                ctx.logger.info(
-                    "Response filtered due to high similarity with previous response"
-                );
-            }
-            return next();
-        }
-
-        responseVerifier.setPreviousResponse(finalRes);
-
-        const sentences = finalRes.split(/(?<=[。?!？！])\s*/);
-
-        sendQueue.updateSendQueue(
-            groupId,
-            config.Bot.BotName,
-			      0,
-            finalRes,
-            0,
-            config.Group.Filter
+    if (!isAllowed) {
+      if (config.Debug.DebugAsInfo) {
+        ctx.logger.info(
+          "Response filtered due to high similarity with previous response"
         );
+      }
+      return next();
+    }
 
-        // 如果 AI 使用了指令
-        if (handledRes.LLMResponse.execute) {
-            handledRes.LLMResponse.execute.forEach(async (command) => {
-                await session.sendQueued(h('execute', {}, command)); // 执行每个指令
-				ctx.logger.info(`已执行指令：${command}`)
-            });
-        }
+    responseVerifier.setPreviousResponse(finalRes);
 
-        let sentencesCopy = [...sentences];
-        while (sentencesCopy.length > 0) {
-            let sentence = sentencesCopy.shift();
-            if (!sentence) { continue; }
-            config.Bot.BotSentencePostProcess.forEach(rule => {
-              const regex = new RegExp(rule.replacethis, "g");
-              if (!rule.tothis) {
-                sentence = sentence.replace(regex, "");
-              } else {
-                sentence = sentence.replace(regex, rule.tothis);
-              }
-            });
-            if (config.Debug.DebugAsInfo) { ctx.logger.info(sentence); }
-            await session.sendQueued(sentence);
+    const sentences = finalRes.split(/(?<=[。?!？！])\s*/);
+
+    sendQueue.updateSendQueue(
+      groupId,
+      config.Bot.BotName,
+      0,
+      finalRes,
+      0,
+      config.Group.Filter
+    );
+
+    // 如果 AI 使用了指令
+    if (handledRes.LLMResponse.execute) {
+      handledRes.LLMResponse.execute.forEach(async (command) => {
+        await session.sendQueued(h('execute', {}, command)); // 执行每个指令
+        ctx.logger.info(`已执行指令：${command}`)
+      });
+    }
+
+    let sentencesCopy = [...sentences];
+    while (sentencesCopy.length > 0) {
+      let sentence = sentencesCopy.shift();
+      if (!sentence) { continue; }
+      config.Bot.BotSentencePostProcess.forEach(rule => {
+        const regex = new RegExp(rule.replacethis, "g");
+        if (!rule.tothis) {
+          sentence = sentence.replace(regex, "");
+        } else {
+          sentence = sentence.replace(regex, rule.tothis);
         }
-    });
+      });
+      if (config.Debug.DebugAsInfo) { ctx.logger.info(sentence); }
+      await session.sendQueued(sentence);
+    }
+  });
 }

--- a/src/utils/api-adapter.ts
+++ b/src/utils/api-adapter.ts
@@ -86,9 +86,9 @@ export async function runChatCompeletion(
 
       // 转换 value 为适当的类型
       otherParams[key] = value === 'true' ? true :
-                         value === 'false' ? false :
-                         !isNaN(value as any) ? Number(value) :
-                         value;
+        value === 'false' ? false :
+          !isNaN(value as any) ? Number(value) :
+            value;
     });
   }
 

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -124,20 +124,6 @@ export function handleResponse(
 */
 export async function processUserContent(session: any): Promise<{ content: string, name: string }> {
   const groupMemberList = session.groupMemberList;
-  // groupMemberList结构示例:
-  // { data: [
-  //    { user:
-  //      { id: '0',
-  //        name: 'YesImBot',
-  //        userId: '0',
-  //        avatar: 'http://q.qlogo.cn/headimg_dl?dst_uin=0&spec=640',
-  //        username: 'YesImBot'
-  //      },
-  //      nick: 'Athena',
-  //      roles: [ 'member' ]
-  //    }
-  //  ]
-  //}
   const regex = /<at id="([^"]+)"(?:\s+name="([^"]+)")?\s*\/>/g;
   // 转码 <at> 消息，把<at id="0" name="YesImBot" /> 转换为 @Athena 或 @YesImBot
   const matches = Array.from(session.content.matchAll(regex));

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -57,7 +57,7 @@ export async function ensurePromptFileExists(
     });
 
     request.on("error", (err) => {
-      fs.unlink(filePath, () => {});
+      fs.unlink(filePath, () => { });
       if (debug)
         ctx.logger.error("An error occurred while downloading prompt file: ", err.message.toString());
     });
@@ -84,7 +84,6 @@ export async function ensurePromptFileExists(
 
 export async function genSysPrompt(
   config: any,
-  curGroupDescription: string,
   curGroupName: string
 ): Promise<string> {
   // 获取当前日期与时间
@@ -133,7 +132,6 @@ export async function genSysPrompt(
   content = content.replaceAll("${curMinute}", curMinute.toString());
   content = content.replaceAll("${curSecond}", curSecond.toString());
 
-  content = content.replaceAll("${curGroupDescription}", curGroupDescription);
   content = content.replaceAll("${curGroupName}", curGroupName);
 
   return content;

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -84,7 +84,8 @@ export async function ensurePromptFileExists(
 
 export async function genSysPrompt(
   config: any,
-  curGroupName: string
+  curGroupName: string,
+  session: any,
 ): Promise<string> {
   // 获取当前日期与时间
   const currentDate = new Date();
@@ -100,7 +101,7 @@ export async function genSysPrompt(
     "utf-8"
   );
 
-  content = content.replaceAll("${config.Bot.BotName}", config.Bot.BotName);
+  content = content.replaceAll("${config.Bot.BotName}", session.groupMemberList.data.find((member) => member.user.id === session.event.selfId).nick,);
   content = content.replaceAll("${config.Bot.WhoAmI}", config.Bot.WhoAmI);
   content = content.replaceAll(
     "${config.Bot.BotHometown}",

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -16,14 +16,14 @@ export class SendQueue {
   constructor() {
     this.sendQueueMap = new Map<
       string,
-      { id: number; sender: string; sender_id:string, content: string }[]
+      { id: number; sender: string; sender_id: string, content: string }[]
     >();
   }
 
   updateSendQueue(
     group: string,
     sender: string,
-	  sender_id: any,
+    sender_id: any,
     content: string,
     id: any,
     FilterList: any
@@ -63,7 +63,7 @@ export class SendQueue {
       const promptArr = queue.map((item) => ({
         id: item.id,
         author: item.sender,
-		author_id: item.sender_id,
+        author_id: item.sender_id,
         msg: item.content,
       }));
       //ctx.logger.info(JSON.stringify(promptArr, null, 2));

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -57,12 +57,13 @@ export class SendQueue {
     }
   }
 
-  getPrompt(group: string): string {
+  getPrompt(group: string, session: any): string {
+    const groupMemberList = session.groupMemberList;
     if (this.sendQueueMap.has(group)) {
       const queue = this.sendQueueMap.get(group);
       const promptArr = queue.map((item) => ({
         id: item.id,
-        author: item.sender,
+        author: groupMemberList.data.find((member) => member.user.id === item.sender_id).nick,
         author_id: item.sender_id,
         msg: item.content,
       }));

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -89,7 +89,6 @@ export class SendQueue {
     if (this.sendQueueMap.has(group)) {
       const queue = this.sendQueueMap.get(group);
       const promptArr = queue.map((item) => {
-        console.log(`Sender ID: ${item.sender_id}`);
         return {
           id: item.id,
           author: groupMemberList.data.find((member) => member.user.id === item.sender_id).nick,

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -61,13 +61,16 @@ export class SendQueue {
   }
 
   // 检查与重置触发计数
-  checkTriggerCount(group: string, nextTriggerCount: number, isAtMentioned: boolean ): boolean {
+  checkTriggerCount(group: string, nextTriggerCount: number, isAtMentioned: boolean): boolean {
     if (this.triggerCountMap.has(group)) {
       const count = this.triggerCountMap.get(group);
       console.log(`距离下一次触发还有: ${count} 条消息`);
-      if (count <= 0 || isAtMentioned) {
+      if (count <= 0) {
         this.triggerCountMap.set(group, nextTriggerCount);
         return true;
+      }
+      if (isAtMentioned) {
+        this.triggerCountMap.set(group, nextTriggerCount);
       }
       return false;
     }

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -10,31 +10,43 @@ function containsFilter(sessionContent: string, FilterList: any): boolean {
 export class SendQueue {
   private sendQueueMap: Map<
     string,
-    { id: number; sender: string; sender_id: string; content: string }[]
+    { id: number; sender: string; sender_id: string; content: string; session: any }[]
   >;
+  private triggerCountMap: Map<string, number>;
 
   constructor() {
     this.sendQueueMap = new Map<
       string,
-      { id: number; sender: string; sender_id: string, content: string }[]
+      { id: number; sender: string; sender_id: string; content: string; session: any }[]
     >();
+    this.triggerCountMap = new Map<string, number>();
   }
 
+  // 消息入队
   updateSendQueue(
     group: string,
     sender: string,
     sender_id: any,
     content: string,
     id: any,
-    FilterList: any
+    FilterList: any,
+    session: any,
+    TriggerCount: number
   ) {
     if (this.sendQueueMap.has(group)) {
       if (containsFilter(content, FilterList)) return;
       const queue = this.sendQueueMap.get(group);
-      queue.push({ id: Number(id), sender: sender, sender_id: sender_id, content: content });
+      queue.push({ id: Number(id), sender: sender, sender_id: sender_id, content: content, session: session });
       this.sendQueueMap.set(group, queue);
     } else {
-      this.sendQueueMap.set(group, [{ id: Number(id), sender: sender, sender_id: sender_id, content: content }]);
+      this.sendQueueMap.set(group, [{ id: Number(id), sender: sender, sender_id: sender_id, content: content, session: session }]);
+    }
+
+    // 更新触发计数
+    if (this.triggerCountMap.has(group)) {
+      this.triggerCountMap.set(group, this.triggerCountMap.get(group) - 1);
+    } else {
+      this.triggerCountMap.set(group, TriggerCount - 1 );
     }
   }
 
@@ -42,18 +54,33 @@ export class SendQueue {
   checkQueueSize(group: string, size: number): boolean {
     if (this.sendQueueMap.has(group)) {
       const queue = this.sendQueueMap.get(group);
-      console.log(`${queue.length} / ${size}`);
+      console.log(`记忆容量: ${queue.length} / ${size}`);
       return queue.length >= size;
     }
     return false;
   }
 
-  // 重置消息队列
-  resetSendQueue(group: string, popNumber: number) {
+  // 检查与重置触发计数
+  checkTriggerCount(group: string, nextTriggerCount: number, isAtMentioned: boolean ): boolean {
+    if (this.triggerCountMap.has(group)) {
+      const count = this.triggerCountMap.get(group);
+      console.log(`距离下一次触发还有: ${count} 条消息`);
+      if (count <= 0 || isAtMentioned) {
+        this.triggerCountMap.set(group, nextTriggerCount);
+        return true;
+      }
+      return false;
+    }
+    return false;
+  }
+
+  // 消息出队到队列长度为maxQueueSize
+  resetSendQueue(group: string, maxQueueSize: number) {
     const queue = this.sendQueueMap.get(group);
     if (queue && queue.length > 0) {
-      const newQueue = queue.slice(popNumber);
+      const newQueue = queue.slice(-maxQueueSize);
       this.sendQueueMap.set(group, newQueue);
+      console.log(`队列已满，已出队至 ${newQueue.length} 条`);
     }
   }
 
@@ -61,12 +88,15 @@ export class SendQueue {
     const groupMemberList = session.groupMemberList;
     if (this.sendQueueMap.has(group)) {
       const queue = this.sendQueueMap.get(group);
-      const promptArr = queue.map((item) => ({
-        id: item.id,
-        author: groupMemberList.data.find((member) => member.user.id === item.sender_id).nick,
-        author_id: item.sender_id,
-        msg: item.content,
-      }));
+      const promptArr = queue.map((item) => {
+        console.log(`Sender ID: ${item.sender_id}`);
+        return {
+          id: item.id,
+          author: groupMemberList.data.find((member) => member.user.id === item.sender_id).nick,
+          author_id: item.sender_id,
+          msg: item.content,
+        };
+      });
       //ctx.logger.info(JSON.stringify(promptArr, null, 2));
       return JSON.stringify(promptArr, null, 2);
     }

--- a/src/utils/verifier.ts
+++ b/src/utils/verifier.ts
@@ -18,34 +18,35 @@ export class ResponseVerifier {
       return true; // Allow if verification is disabled or no previous response
     }
 
-    if (this.config.Verifier.API.AIModel.includes("embedding")) {
-      // 使用 embedding 模型验证相似度
-      const previousEmbedding = await runEmbedding(
-        this.config.Verifier.API.APIType,
-        this.config.Verifier.API.BaseURL,
-        this.config.Verifier.API.UID,
-        this.config.Verifier.API.APIKey,
-        this.config.Verifier.API.AIModel,
-        this.previousResponse
-      );
+    try {
+      if (this.config.Verifier.API.AIModel.includes("embedding")) {
+        // 使用 embedding 模型验证相似度
+        const previousEmbedding = await runEmbedding(
+          this.config.Verifier.API.APIType,
+          this.config.Verifier.API.BaseURL,
+          this.config.Verifier.API.UID,
+          this.config.Verifier.API.APIKey,
+          this.config.Verifier.API.AIModel,
+          this.previousResponse
+        );
 
-      const currentEmbedding = await runEmbedding(
-        this.config.Verifier.API.APIType,
-        this.config.Verifier.API.BaseURL,
-        this.config.Verifier.API.UID,
-        this.config.Verifier.API.APIKey,
-        this.config.Verifier.API.AIModel,
-        currentResponse
-      );
+        const currentEmbedding = await runEmbedding(
+          this.config.Verifier.API.APIType,
+          this.config.Verifier.API.BaseURL,
+          this.config.Verifier.API.UID,
+          this.config.Verifier.API.APIKey,
+          this.config.Verifier.API.AIModel,
+          currentResponse
+        );
 
-      const similarityScore = this.calculateCosineSimilarity(
-        previousEmbedding.response.data[0].embedding,
-        currentEmbedding.response.data[0].embedding
-      );
+        const similarityScore = this.calculateCosineSimilarity(
+          previousEmbedding.response.data[0].embedding,
+          currentEmbedding.response.data[0].embedding
+        );
 
-      return similarityScore <= this.config.Verifier.SimilarityThreshold;
-    } else {
-      const sysPrompt = `请分析以下两段文本的相似度，返回一个0到1之间的数字，精确到小数点后两位。
+        return similarityScore <= this.config.Verifier.SimilarityThreshold;
+      } else {
+        const sysPrompt = `请分析以下两段文本的相似度，返回一个0到1之间的数字，精确到小数点后两位。
 0表示完全不同，1表示完全相同。只返回数字，不要有任何其他文字。
 
 判断标准：
@@ -54,9 +55,8 @@ export class ResponseVerifier {
 3. 如果两段文本表达了相同的情感或态度，认为相似度较高
 
 接下来我将给你提供两个句子, 分别用 'A:' 和 'B:' 标识。`;
-      const promptInput = `A: ${this.previousResponse}\nB: ${currentResponse}`;
+        const promptInput = `A: ${this.previousResponse}\nB: ${currentResponse}`;
 
-      try {
         const response = await runChatCompeletion(
           this.config.Verifier.API.APIType,
           this.config.Verifier.API.BaseURL,
@@ -70,10 +70,10 @@ export class ResponseVerifier {
 
         const similarityScore = this.extractSimilarityScore(response);
         return similarityScore <= this.config.Verifier.SimilarityThreshold;
-      } catch (error) {
-        console.error("Verification failed:", error);
-        return true;
       }
+    } catch (error) {
+      console.error("Verification failed:", error);
+      return true;
     }
   }
   // 计算向量的余弦相似度


### PR DESCRIPTION
重写了队列的处理逻辑，现在可以分别设置第一次触发回复的消息条数和bot的上下文条数了。
改用guild而不是channel，以通过groupMemberList按群昵称获取成员名字，而不是qq昵称，这样更像人类一些。
反转义`<at>`消息，如果LLM的回复中包含`@xxx `，那么就会从groupMemberList中查找`xxx`的id，构造`<at id="???" name="xxx" />`替换进去。
修改了从LLM的回复获取合法JSON的方法，现在使用正则匹配两个花括号的内容，以防止BOT回复本身中提到的<code>```</code>或`json`被替换。
修正了之前的误解，把replyToID改回了reply，相应的默认gbnf也有对应的更改。
删掉了GroupDescription，因为Koishi无法获取它。
使用VSCode格式化了代码。