### PR TITLE
[fix & feat] 沙盒模式获取 id; Embedding 改为可选配置; 新增部分测试内容

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -153,7 +153,7 @@ export abstract class BaseAdapter {
     input: any,
     AllowErrorFormat: boolean,
     config: any,
-    session: any,
+    groupMemberList: any,
   ): Promise<{
     res: string;
     resNoTag: string;
@@ -238,7 +238,7 @@ export abstract class BaseAdapter {
           break;
         }
       }
-      if (finalResponse === "") throw new Error(`LLM provides unexpected response: ${res}`);
+      if (finalResponse === "" && !LLMResponse.execute?.length) throw new Error(`LLM provides unexpected response: ${res}`);
     }
 
     // 复制一份finalResonse为finalResponseNoTag，作为添加到队列中的bot消息内容
@@ -251,7 +251,7 @@ export abstract class BaseAdapter {
       }) + finalResponse;
 
     // 使用 groupMemberList 反转义 <at> 消息
-    const groupMemberList: { nick: string; user: { name: string; id: string } }[] = session.groupMemberList.data;
+    // const groupMemberList: { nick: string; user: { name: string; id: string } }[] =  groupMemberList.data;
 
     if (!["群昵称", "用户昵称"].includes(config.Bot.NickorName)) {
       throw new Error(`Unsupported NickorName value: ${config.Bot.NickorName}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,4 @@
-import {
-  Schema
-} from "koishi";
+import { Schema } from "koishi";
 
 export const configSchema: any = Schema.object({
   Group: Schema.object({
@@ -161,14 +159,23 @@ export const configSchema: any = Schema.object({
   //     ])
   // ]),
 
-  Embedding: Schema.object({
-    APIType: Schema.union(["OpenAI", "Custom"]).default("OpenAI").description("Embedding API 类型"),
-    BaseURL: Schema.string().default("https://api.openai.com").description("Embedding API 基础 URL"),
-    APIKey: Schema.string().required().description("API 令牌"),
-    EmbeddingModel: Schema.string().default("text-embedding-3-large").description("Embedding 模型 ID"),
-    RequestBody: Schema.string().description("自定义请求体。其中：`<text>`（包含尖括号）会被替换成用于计算嵌入向量的文本；`<apikey>`（包含尖括号）会被替换成此页面设置的 API 密钥；<model>（包含尖括号）会被替换成此页面设置的模型名称"),
-    GetVecRegex: Schema.string().description("从自定义Embedding服务提取嵌入向量的正则表达式。注意转义"),
-  }).description("Embedding 模型相关配置，用于表情语义相似度验证"), // 日后可能也会用于记忆中枢
+  Embedding: Schema.intersect([
+    Schema.object({
+      Enabled: Schema.boolean().default(false),
+    }).description('是否启用 Embedding'),
+    Schema.union([
+      Schema.object({
+        Enabled: Schema.const(true).required(),
+        APIType: Schema.union(["OpenAI", "Custom"]).default("OpenAI").description("Embedding API 类型"),
+        BaseURL: Schema.string().default("https://api.openai.com").description("Embedding API 基础 URL"),
+        APIKey: Schema.string().required().description("API 令牌"),
+        EmbeddingModel: Schema.string().default("text-embedding-3-large").description("Embedding 模型 ID"),
+        RequestBody: Schema.string().description("自定义请求体。其中：`<text>`（包含尖括号）会被替换成用于计算嵌入向量的文本；`<apikey>`（包含尖括号）会被替换成此页面设置的 API 密钥；<model>（包含尖括号）会被替换成此页面设置的模型名称"),
+        GetVecRegex: Schema.string().description("从自定义Embedding服务提取嵌入向量的正则表达式。注意转义"),
+      }),
+      Schema.object({})
+    ])
+  ]),
 
   ImageViewer: Schema.object({
     How: Schema.union(["LLM API 自带的多模态能力", "图片描述服务", "替换成[图片:summary]", "替换成[图片]", "不做处理，以<img>标签形式呈现"])

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,16 @@ export function apply(ctx: Context, config: Config) {
     if (!session.groupMemberList && !isPrivateChat) {
       session.groupMemberList = await session.bot.getGuildMemberList(session.guildId);
       session.groupMemberList.data.forEach(member => {
+        // 沙盒获取到的 member 数据不一样
+        if (member.userId === member.username && !member.user) {
+          member.user = {
+            id: member.userId,
+            name: member.username,
+            userId: member.userId,
+          };
+          member.nick = member.username;
+          member.roles = ['member'];
+        }
         if (!member.nick) {
           member.nick = member.user.name || member.user.username;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,7 @@ export function apply(ctx: Context, config: Config) {
       response,
       config.Debug.AllowErrorFormat,
       config,
-      session
+      session.groupMemberList.data
     );
 
     const finalRes: string = handledRes.res;

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -163,7 +163,7 @@ export async function runEmbedding(
         throw new Error("无法从响应中提取向量");
       }
       try {
-        vector = JSON.parse(match[1]);
+        vector = JSON.parse(match[0]);
         saveToCache(cacheFile, vector);
         return vector;
       } catch (e) {

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -31,7 +31,9 @@ export default {
       },
     ],
   },
-  Bot: {},
+  Bot: {
+    NickorName: "用户昵称"
+  },
   Debug: {
     DebugAsInfo: false,
     DisableGroupFilter: true,

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -31,7 +31,6 @@ export default {
       },
     ],
   },
-
   Bot: {},
   Debug: {
     DebugAsInfo: false,
@@ -39,4 +38,12 @@ export default {
     AllowErrorFormat: true,
     UpdatePromptOnLoad: false,
   },
+  Embedding: {
+    APIType: "Custom",
+    BaseURL: "http://localhost:11434/api/embeddings",
+    APIKey: "sk-xxxxxxx",
+    EmbeddingModel: "nomic-embed-text",
+    RequestBody: "{\"prompt\": \"<text>\", \"model\": \"<model>\"}",
+    GetVecRegex: "(?<=\"embedding\":).*?(?=})"
+  }
 };

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,103 +1,89 @@
 import { Context } from "koishi";
 import mock, { MessageClient } from "@koishijs/plugin-mock";
-import { describe, test, beforeAll, afterAll, jest } from "@jest/globals";
+import { beforeAll, afterAll, jest, it } from "@jest/globals";
+import assert from "assert";
 
 import * as help from "@koishijs/plugin-help";
 import * as logger from "@koishijs/plugin-logger";
 import * as yesimbot from "../src/index";
 
 import config from "./config";
-import { sendRequest } from "../src/utils/tools";
+import { emojiManager } from "../src/utils/content";
 
 // 拦截 sendRequest 函数请求
-jest.mock("../src/utils/tools");
-
-// 通过 url 细分, 返回不同的 response
-// TODO: 通过创建特定规则的 url, 测试不同格式的回复
-// 比如: /custom/wrong_json 对应错误的 json 输出
-//@ts-ignore
-sendRequest.mockImplementation((url: string) => {
-  const content =
-    '{\n  "status": "success",\n  "logic": "<logic>",\n  "reply": "下雨了记得带伞哦~",\n  "select": -1,\n  "check": "<check>",\n  "finReply": "下雨了记得带伞哦~",\n  "execute": [\n    {\n      "action": "send_message",\n      "params": {\n        "msg": "下雨了记得带伞哦~",\n        "to": "group1"\n      }\n    }\n  ]\n}';
-  if (url.startsWith("/openai")) {
-    return {
-      id: "chatcmpl-123",
-      object: "chat.completion",
-      created: 1677652288,
-      model: "gpt-3.5-turbo-0613",
-      system_fingerprint: "fp_44709d6fcb",
-      choices: [
-        {
-          index: 0,
-          message: {
-            role: "assistant",
-            content: content,
-          },
-          finish_reason: "stop",
-        },
-      ],
-      usage: {
-        prompt_tokens: 9,
-        completion_tokens: 12,
-        total_tokens: 21,
-      },
-    };
-  } else if (url.startsWith("/cloudflare")) {
-    return {
-      result: {
-           response: content
-      },
-      success: true,
-      errors: [],
-      messages: []
+jest.mock("../src/utils/tools", () => {
+  const originalModule = jest.requireActual("../src/utils/tools");
+  return {
+    //@ts-ignore
+    ...originalModule,
+    //@ts-ignore
+    sendRequest: jest.fn().mockImplementation(async (url: string, APIKey: string, requestBody: any) => {
+          // 通过 url 细分, 返回不同的 response
+          // TODO: 通过创建特定规则的 url, 测试不同格式的回复
+          // 比如: /custom/wrong_json 对应错误的 json 输出
+          const content =
+            '{\n  "status": "success",\n  "logic": "<logic>",\n  "reply": "下雨了记得带伞哦~",\n  "select": -1,\n  "check": "<check>",\n  "finReply": "下雨了记得带伞哦~",\n  "execute": [\n    {\n      "action": "send_message",\n      "params": {\n        "msg": "下雨了记得带伞哦~",\n        "to": "group1"\n      }\n    }\n  ]\n}';
+          if (url.startsWith("/openai/embedding")) {
+            return;
+          } else if (url.startsWith("http://localhost:11434/api/embeddings")) {
+            //@ts-ignore
+            return await originalModule.sendRequest(url, APIKey, requestBody);
+          } else if (url.startsWith("/openai")) {
+            return {
+              choices: [
+                {
+                  message: {
+                    content: content,
+                  },
+                },
+              ],
+              usage: {
+                prompt_tokens: 9,
+                completion_tokens: 12,
+                total_tokens: 21,
+              },
+            };
+          } else if (url.startsWith("/cloudflare")) {
+            return {
+              result: {
+                response: content,
+              },
+            };
+          } else if (url.startsWith("/ollama")) {
+            return {
+              message: {
+                content: content,
+              },
+              prompt_eval_count: 26,
+              eval_count: 298,
+            };
+          } else if (url.startsWith("/custom")) {
+            return {
+              choices: [
+                {
+                  message: {
+                    content: content,
+                  },
+                },
+              ],
+              usage: {
+                prompt_tokens: 4922,
+                completion_tokens: 253,
+                total_tokens: 5175,
+              },
+            };
+          } else throw new Error(`不支持的 API 类型: ${url}`);
+        }
+      ),
   };
-  } else if (url.startsWith("/ollama")) {
-    return {
-      model: "llama3.2",
-      created_at: "2023-12-12T14:13:43.416799Z",
-      message: {
-        role: "assistant",
-        content: content,
-      },
-      done: true,
-      total_duration: 5191566416,
-      load_duration: 2154458,
-      prompt_eval_count: 26,
-      prompt_eval_duration: 383809000,
-      eval_count: 298,
-      eval_duration: 4799921000,
-    };
-  } else if (url.startsWith("/custom")) {
-    return {
-      id: "chatcmpl-89DA0jsir8Nwf1q8zXPVZ6lcHT6kT",
-      object: "chat.completion",
-      created: 1732205631,
-      model: "glm-4-flash",
-      choices: [
-        {
-          index: 0,
-          message: {
-            role: "assistant",
-            content: content,
-          },
-          finish_reason: "stop",
-        },
-      ],
-      usage: {
-        prompt_tokens: 4922,
-        completion_tokens: 253,
-        total_tokens: 5175,
-      },
-    };
-  } else throw new Error(`不支持的 API 类型: ${url}`);
 });
 
 function createUser(id: string) {
   return {
     id: id,
     name: `User<${id}>`,
-    nick: `Nick<${id}>`
-  }
+    nick: `Nick<${id}>`,
+  };
 }
 
 class Test {
@@ -129,8 +115,8 @@ class Test {
     };
 
     this.client.bot.getUser = async (id, guildId) => {
-      return createUser(id)
-    }
+      return createUser(id);
+    };
 
     // 等待 app 启动完成
     beforeAll(() => this.app.start());
@@ -138,54 +124,77 @@ class Test {
   }
 
   test() {
-    describe("", () => {
-      // 依次测试每个适配器, 保证能正确处理 ai 消息
-      test("适配器解析", async () => {
-        await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
-        await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
-        await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
-        await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
-      })
+    
+    // 依次测试每个适配器, 保证能正确处理 ai 消息
+    it("适配器解析", async () => {
+      await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
+      await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
+      await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
+      await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
+    });
 
-      test("AT 立即回复", async () => {
-        await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="YesImBot" /> 你好`);
-      });
+    it("AT 立即回复", async () => {
+      await this.client.shouldReply(
+        `<at id="${this.client.bot.selfId}" name="YesImBot" /> 你好`
+      );
+    });
 
-      test("达到初始触发计数(3)", async () => {
-        await this.client.receive("清除记忆");
-        await this.client.shouldNotReply("第一条消息");
-        await this.client.shouldNotReply("第二条消息");
-        await this.client.shouldReply("第三条消息");
-      });
+    it("达到初始触发计数(3)", async () => {
+      await this.client.receive("清除记忆");
+      await this.client.shouldNotReply("第一条消息");
+      await this.client.shouldNotReply("第二条消息");
+      await this.client.shouldReply("第三条消息");
+    });
 
-      // test("回复间隔消息数(1)", async () => {
-      //   await this. client.receive("清除记忆");
-      //   await this. client.shouldNotReply("第一条消息");
-      //   await this. client.shouldNotReply("第二条消息");
-      //   await this. client.shouldReply("第三条消息");
-      //   await this. client.shouldNotReply("第四条消息");
-      //   await this. client.shouldReply("第五条消息");
-      // });
+    // it("回复间隔消息数(1)", async () => {
+    //   await this. client.receive("清除记忆");
+    //   await this. client.shouldNotReply("第一条消息");
+    //   await this. client.shouldNotReply("第二条消息");
+    //   await this. client.shouldReply("第三条消息");
+    //   await this. client.shouldNotReply("第四条消息");
+    //   await this. client.shouldReply("第五条消息");
+    // });
 
-      test("私聊", async () => {
-        const privateClient = this.app.mock.client("12345678")
-        await privateClient.receive("清除记忆");
-        await privateClient.shouldReply(`<at id="${privateClient.bot.selfId}" name="" /> 你好`);
-      })
+    it("私聊", async () => {
+      const privateClient = this.app.mock.client("12345678");
+      await privateClient.receive("清除记忆");
+      await privateClient.shouldReply(`<at id="${privateClient.bot.selfId}" name="" /> 你好`);
+    });
 
-      test("清除记忆", async () => {
-        await this.client.receive("清除记忆");
-        await this.client.receive("这是一条消息")
-        await this.client.shouldReply("清除记忆", `已清除关于 ${this.client.channelId} 的记忆`)
-        await this.client.shouldReply("清除记忆", `未找到关于 ${this.client.channelId} 的记忆`)
-        await this.client.shouldReply("清除记忆 -t 10000000", `未找到关于 10000000 的记忆`)
-        const privateClient = this.app.mock.client("12345678")
-        await privateClient.receive("这是一条消息")
-        await privateClient.shouldReply("清除记忆", `已清除关于 private:${this.client.userId} 的记忆`)
-        await privateClient.shouldReply("清除记忆", `未找到关于 private:${this.client.userId} 的记忆`)
-        await privateClient.shouldReply("清除记忆 -t 10000000", `未找到关于 10000000 的记忆`)
-        await privateClient.shouldReply("清除记忆 -t private:10000000", `未找到关于 private:10000000 的记忆`)
-      })
+    it("清除记忆", async () => {
+      await this.client.receive("清除记忆");
+      await this.client.receive("这是一条消息");
+      await this.client.shouldReply("清除记忆", `已清除关于 ${this.client.channelId} 的记忆`)
+      await this.client.shouldReply("清除记忆", `未找到关于 ${this.client.channelId} 的记忆`)
+      await this.client.shouldReply("清除记忆 -t 10000000", `未找到关于 10000000 的记忆`)
+      const privateClient = this.app.mock.client("12345678")
+      await privateClient.receive("这是一条消息")
+      await privateClient.shouldReply("清除记忆", `已清除关于 private:${this.client.userId} 的记忆`)
+      await privateClient.shouldReply("清除记忆", `未找到关于 private:${this.client.userId} 的记忆`)
+      await privateClient.shouldReply("清除记忆 -t 10000000", `未找到关于 10000000 的记忆`)
+      await privateClient.shouldReply("清除记忆 -t private:10000000", `未找到关于 private:10000000 的记忆`)
+    });
+
+    it("表情解析", async () => {
+      // <face id="277" name="汪汪" platform="onebot"><img src="https://koishi.js.org/QFace/static/s277.png"/></face>
+      const at = `<at id="${this.client.bot.selfId}" name="" />`
+      const face = `<face id="277" name="汪汪" platform="onebot"><img src="https://koishi.js.org/QFace/static/s277.png"/></face>`
+      assert.equal(await emojiManager.getIdByName("惊讶"), 0);
+      assert.equal(await emojiManager.getNameById("277"), "汪汪");
+    });
+
+    it("表情解析Embedding", async () => {
+      assert.equal(
+        await emojiManager.getNameByTextSimilarity("征服世界", config),
+        "奋斗"
+      );
+    });
+
+    it("表情解析Embedding", async () => {
+      assert.equal(
+        await emojiManager.getNameByTextSimilarity("火力全开", config),
+        "怄火"
+      );
     });
   }
 }
@@ -193,5 +202,3 @@ class Test {
 const tester = new Test();
 
 tester.test();
-
-

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -9,6 +9,7 @@ import * as yesimbot from "../src/index";
 
 import config from "./config";
 import { emojiManager } from "../src/utils/content";
+import { CustomAdapter } from "../src/adapters";
 
 // 拦截 sendRequest 函数请求
 jest.mock("../src/utils/tools", () => {
@@ -195,6 +196,49 @@ class Test {
         await emojiManager.getNameByTextSimilarity("火力全开", config),
         "怄火"
       );
+    });
+
+    it("handleResponse", async () => {
+      const adapter = new CustomAdapter(
+        "/custom/static",
+        "",
+        "static"
+      );
+
+      const content = JSON.stringify({
+        "status": "success",
+        "logic": "",
+        "select": -1,
+        "reply": "",
+        "check": "", //
+        "finReply": "",
+        "execute": [
+          "echo 123"
+        ]
+      })
+
+      const input = {
+        choices: [
+          {
+            message: {
+              content: content,
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 4922,
+          completion_tokens: 253,
+          total_tokens: 5175,
+        },
+      };
+
+      const { res, resNoTag, LLMResponse, usage } = await adapter.handleResponse(
+        input,
+        true,
+        config,
+        //@ts-ignore
+        (await this.client.bot.getGuildMemberList(this.client.channelId)).data
+      )
     });
   }
 }


### PR DESCRIPTION
- 将 `adapter.handleResponse` 与 `session` 解耦合以便于单独测试
- `LLMResponse.execute` 不为空时不抛出错误
- `Embedding` 改为可选配置, 防止第一次启动出错 https://github.com/HydroGest/YesImBot/commit/c317adbc4844b459ba71f0922aea22a8f2148cfc
- 修复 [Custom embedding 正则解析](https://github.com/HydroGest/YesImBot/commit/41d2a097a27c35d5989d3d172c6c95ea714d2f5f)