### PR TITLE
[feat] 添加消息队列存档，关闭koishi时不会清空记忆了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ yarn.lock
 
 coverage
 data/logs
+data/.vector_cache
+data/queue.json
+data/emojis.json

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,5 +1,7 @@
 import { getMemberName } from './prompt';
 import JSON5 from "json5";
+import fs from 'fs';
+import path from 'path';
 
 function containsFilter(sessionContent: string, FilterList: any): boolean {
   for (const filterString of FilterList) {
@@ -16,13 +18,47 @@ export class SendQueue {
     { id: number; sender: string; sender_id: string; content: string }[]
   >;
   private triggerCountMap: Map<string, number>;
+  private readonly filePath: string;
 
   constructor() {
+    this.filePath = path.join(__dirname, '../../data/queue.json')
     this.sendQueueMap = new Map<
       string,
       { id: number; sender: string; sender_id: string; content: string }[]
     >();
     this.triggerCountMap = new Map<string, number>();
+    this.loadFromFile();
+  }
+
+  // 保存数据到文件
+  public saveToFile(): void {
+    try {
+      const data = {
+        sendQueueMap: Object.fromEntries(this.sendQueueMap),
+        triggerCountMap: Object.fromEntries(this.triggerCountMap)
+      };
+      fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+    } catch (error) {
+      console.error('存档队列数据失败:', error);
+    }
+  }
+
+  // 从文件加载数据
+  private loadFromFile(): void {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const fileContent = fs.readFileSync(this.filePath, 'utf-8');
+        const data = JSON.parse(fileContent);
+
+        // 将普通对象转换回 Map
+        this.sendQueueMap = new Map(Object.entries(data.sendQueueMap));
+        this.triggerCountMap = new Map(Object.entries(data.triggerCountMap));
+
+        console.log('已从文件加载队列数据');
+      }
+    } catch (error) {
+      console.error('加载队列数据失败:', error);
+    }
   }
 
   // 消息入队
@@ -48,6 +84,7 @@ export class SendQueue {
     // 更新触发计数
     const currentCount = this.triggerCountMap.get(group) ?? TriggerCount;
     this.triggerCountMap.set(group, selfId === sender_id ? currentCount : currentCount - 1); // 自己发的消息不计数
+    this.saveToFile();
   }
 
   // 检查队列长度
@@ -67,10 +104,12 @@ export class SendQueue {
       console.log(`距离下一次触发还有: ${count} 条消息`);
       if (count <= 0) {
         this.triggerCountMap.set(group, nextTriggerCount);
+        this.saveToFile();
         return true;
       }
       if (isAtMentioned) {
         this.triggerCountMap.set(group, nextTriggerCount);
+        this.saveToFile();
       }
       return false;
     }
@@ -83,6 +122,7 @@ export class SendQueue {
     if (queue && queue.length > 0) {
       const newQueue = queue.slice(-maxQueueSize);
       this.sendQueueMap.set(group, newQueue);
+      this.saveToFile();
       console.log(`队列已满，已出队至 ${newQueue.length} 条`);
     }
   }
@@ -92,6 +132,7 @@ export class SendQueue {
     if (this.sendQueueMap.has(group)) {
       this.sendQueueMap.delete(group);
       this.triggerCountMap.delete(group);
+      this.saveToFile();
       return true;
     } else {
       return false;
@@ -102,7 +143,6 @@ export class SendQueue {
     if (this.sendQueueMap.has(group)) {
       const queue = this.sendQueueMap.get(group);
       const promptArr = await Promise.all(queue.map(async (item) => {
-        // console.log(`item.content: ${item.content}`);
         return {
           id: item.id,
           author: await getMemberName(config, session, item.sender_id),

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -33,7 +33,7 @@ export async function sendRequest(url: string, APIKey: string, requestBody: any,
 }
 
 
-// 缓存相关 考虑把它们放到一个单独的文件中
+// 缓存相关 考虑把它们放到一个单独的文件中 这样做基于md5的图片缓存的时候也可以用到
 function getCacheDir(): string {
   const cacheDir = path.join(__dirname, '../../data/.vector_cache');
   if (!fs.existsSync(cacheDir)) {


### PR DESCRIPTION
- SendQueue发生变化时，把SendQueue保存到data/queue.json中
- 创建SendQueue时，先读取存档
- 这不是BOT高级记忆功能，这只是为了BOT的记忆不被意外清空