### PR TITLE
[feat] 混合记忆与记忆槽位

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -5,6 +5,7 @@ import { Config } from "../config";
 
 interface Response {
   status: "skip" | "success";
+  session_id: string;
   logic: string;
   reply: string;
   select: number;
@@ -158,6 +159,8 @@ export abstract class BaseAdapter {
   ): Promise<{
     res: string;
     resNoTag: string;
+    replyTo: string;
+    quote: number;
     LLMResponse: any;
     usage?: Usage;
   }> {
@@ -198,8 +201,9 @@ export abstract class BaseAdapter {
     // 正版回复：
     // {
     //   "status": "success", // "success" 或 "skip" (跳过回复)
+    //   "session_id": "123456789", // 要把finReply发送到的会话id
     //   "logic": "", // LLM思考过程
-    //   "select": -1, // 回复引用的消息id
+    //   "select": "-1", // 回复引用的消息id
     //   "reply": "", // 初版回复
     //   "check": "", // 检查初版回复是否符合 "消息生成条例" 过程中的检查逻辑。
     //   "finReply": "" // 最终版回复
@@ -291,6 +295,8 @@ export abstract class BaseAdapter {
     return {
       res: finalResponse,
       resNoTag: finalResponseNoTag,
+      replyTo: LLMResponse.session_id,
+      quote: LLMResponse.select,
       LLMResponse: LLMResponse,
       usage: usage,
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -189,7 +189,7 @@ export const configSchema: any = Schema.object({
     Server: Schema.union(["百度AI开放平台", "自己搭建的服务", "另一个LLM"]).default("百度AI开放平台").description("图片查看器使用的服务提供商"),
     BaseURL: Schema.string()
       .default("http://127.0.0.1")
-      .description("另一个LLM或自己搭建的图片描述服务或另一个LLM的完整 URL"),
+      .description("自己搭建的图片描述服务或另一个LLM的完整 URL"),
     Model: Schema.string().default("gpt-4o-mini").description("使用另一个LLM时的模型名称"),
     RequestBody: Schema.string().description("自己搭建的图片描述服务需要的请求体。其中：`<url>`（包含尖括号）会被替换成消息中出现的图片的url；`<base64>`(包含尖括号)会被替换成图片的base64（自带`data:image/jpeg;base64,`头，无需另行添加）；`<question>`（包含尖括号）会被替换成此页面设置的针对输入图片的问题；`<apikey>`（包含尖括号）会被替换成此页面设置的图片描述服务可能需要的 API 密钥"),
     GetDescRegex: Schema.string().description("从自己搭建的图片描述服务提取所需信息的正则表达式。注意转义"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,7 @@ export interface Config {
     BotGender: string;
     BotHabbits: string;
     BotBackground: string;
+    WordsPerSecond: number;
     CuteMode: boolean;
     BotSentencePostProcess: {
       replacethis: string;
@@ -94,7 +95,7 @@ export interface Config {
       Target?: string;
     };
     DebugAsInfo: boolean;
-    DisableGroupFilter: boolean;
+    FirsttoAll: boolean;
     UpdatePromptOnLoad: boolean;
     AllowErrorFormat: boolean;
   };
@@ -104,7 +105,8 @@ export const Config: Schema<Config> = Schema.object({
   Group: Schema.object({
     AllowedGroups: Schema.array(Schema.string())
       .required()
-      .description("允许的群聊"),
+      .role("table")
+      .description("记忆槽位。填入一个或多个群号，用半角逗号分隔。用\"private:\"指定私聊，用\"all\"指定所有群聊，用\"private:all\"指定所有私聊。同一个槽位的聊天将共用同一份记忆。如果多个槽位都包含同一群号，第一个包含该群号的槽位将被应用"),
     SendQueueSize: Schema.number()
       .default(20)
       .min(1)
@@ -371,6 +373,13 @@ export const Config: Schema<Config> = Schema.object({
     BotBackground: Schema.string()
       .default("高中女生")
       .description("Bot 的背景"),
+    WordsPerSecond: Schema.number()
+      .default(2)
+      .min(0.1)
+      .max(360)
+      .step(0.1)
+      .role("slider")
+      .description("Bot 的打字速度（每秒字数）"),
     BotSentencePostProcess: Schema.array(
       Schema.object({
         replacethis: Schema.string().description("需要替换的文本"),
@@ -403,9 +412,9 @@ export const Config: Schema<Config> = Schema.object({
     DebugAsInfo: Schema.boolean()
       .default(false)
       .description("在控制台显示 Debug 消息"),
-    DisableGroupFilter: Schema.boolean()
+    FirsttoAll: Schema.boolean()
       .default(false)
-      .description("禁用聊群筛选器，接收并回复所有群的消息"),
+      .description("记忆槽位的行为改为：如果多个槽位都包含同一群号，所有包含该群号的槽位都将被应用"),
     UpdatePromptOnLoad: Schema.boolean()
       .default(true)
       .description("每次启动时尝试更新 Prompt 文件"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ export function apply(ctx: Context, config: Config) {
         ]
       };
 
-      session.guildName = `与${session.bot.user.name}的私聊`;
+      session.guildName = `${session.bot.user.name}与${session.event.user.name}的私聊`;
     }
 
     if (config.Debug.DebugAsInfo)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { ResponseVerifier } from "./utils/verifier";
 
 import { Config } from "./config";
 
+import { isGroupAllowed } from "./utils/tools";
+
 import { genSysPrompt, ensurePromptFileExists, getMemberName, getBotName } from "./utils/prompt";
 
 import { SendQueue } from "./utils/queue";
@@ -136,11 +138,11 @@ export function apply(ctx: Context, config: Config) {
     if (config.Debug.DebugAsInfo)
       ctx.logger.info(`New message received, guildId = ${groupId}`);
 
-    if (
-      !config.Group.AllowedGroups.includes(groupId) &&
-      !config.Debug.DisableGroupFilter
-    )
-      return next();
+    if (!config.Group.AllowedGroups?.length) return next();
+
+    const [isGuildAllowed, matchedConfig] = isGroupAllowed(groupId, config.Group.AllowedGroups, config.Debug.FirsttoAll);
+    if (!isGuildAllowed) return next();
+    const mergeQueueFrom = matchedConfig;
 
     const userContent = await processUserContent(config, session);
 
@@ -163,6 +165,7 @@ export function apply(ctx: Context, config: Config) {
     // 并且消息没有提及机器人或者提及了机器人但随机条件未命中 (!(isAtMentioned && shouldReactToAt))
     // 那么就会执行内部的代码，即跳过这个中间件，不向api发送请求
     const isQueueFull: boolean = sendQueue.checkQueueSize(groupId, config.Group.SendQueueSize);
+    const isMixedQueueFull: boolean = sendQueue.checkMixedQueueSize(mergeQueueFrom, config.Group.SendQueueSize);
     const loginStatus = await session.bot.getLogin();
     const isBotOnline = loginStatus.status === 1;
     const atRegex = new RegExp(`<at (id="${session.bot.selfId}".*?|type="all".*?${isBotOnline ? '|type="here"' : ''}).*?/>`);
@@ -174,10 +177,13 @@ export function apply(ctx: Context, config: Config) {
     if (isQueueFull) {
       sendQueue.resetSendQueue(groupId, config.Group.SendQueueSize);
     }
+    if (isMixedQueueFull) {
+      ctx.logger.info("记忆槽位已满，超出的旧消息将被遗忘");
+    }
 
     if (!isTriggerCountReached && !(isAtMentioned && shouldReactToAt)) {
       if (config.Debug.DebugAsInfo)
-        ctx.logger.info(await sendQueue.getPrompt(groupId, config, session));
+        ctx.logger.info(await sendQueue.getPrompt(mergeQueueFrom, config, session));
       return next();
     }
 
@@ -204,7 +210,7 @@ export function apply(ctx: Context, config: Config) {
       session.guildName ? session.guildName : session.event.user?.name,
       session
     );
-    const chatData: string = await sendQueue.getPrompt(groupId, config, session);
+    const chatData: string = await sendQueue.getPrompt(mergeQueueFrom, config, session);
     const curAPI = status.getStatus();
     status.updateStatus(adapters.length);
 
@@ -229,6 +235,8 @@ export function apply(ctx: Context, config: Config) {
     const handledRes: {
       res: string;
       resNoTag: string;
+      replyTo: string;
+      quote: number;
       LLMResponse: any;
       usage?: any;
     } = await adapters[curAPI].handleResponse(
@@ -239,9 +247,20 @@ export function apply(ctx: Context, config: Config) {
     );
 
     const finalRes: string = handledRes.res;
+    let finalReplyTo: string = handledRes.replyTo;
+
+    if (sendQueue.findGroupByMessageId(handledRes.quote, mergeQueueFrom) === null) {
+      if (config.Debug.DebugAsInfo) {
+        ctx.logger.info(
+          `Quote message not found, using session_id.`
+        );
+      }
+    } else {
+      finalReplyTo = sendQueue.findGroupByMessageId(handledRes.quote, mergeQueueFrom);
+    }
 
     if (config.Debug.LogicRedirect.Enabled) {
-      const template = `回复于 ${groupId} 的消息已生成，来自 API ${curAPI}:
+      const template = `回复于 ${finalReplyTo} 的消息已生成，来自 API ${curAPI}:
 内容: ${(handledRes.LLMResponse.finReply ? handledRes.LLMResponse.finReply : handledRes.LLMResponse.reply)}
 ---
 逻辑: ${handledRes.LLMResponse.logic}
@@ -270,7 +289,7 @@ export function apply(ctx: Context, config: Config) {
     const sentences = finalRes.split(/(?<=[。?!？！])\s*/);
 
     sendQueue.updateSendQueue(
-      groupId,
+      finalReplyTo,
       await getBotName(config, session),
       session.event.selfId,
       handledRes.resNoTag,
@@ -282,14 +301,14 @@ export function apply(ctx: Context, config: Config) {
 
     // 如果 AI 使用了指令
     if (handledRes.LLMResponse.execute) {
-      handledRes.LLMResponse.execute.forEach(async (command) => {
-        try {
-          await session.sendQueued(h("execute", {}, command)); // 执行每个指令
-          ctx.logger.info(`已执行指令：${command}`);
-        } catch (error) {
-          ctx.logger.error(`执行指令<${command.toString()}>时出错: ${error}`)
-        }
-      });
+      for (const command of handledRes.LLMResponse.execute) {
+      try {
+        await session.bot.sendMessage(finalReplyTo, h("execute", {}, command)); // 执行每个指令
+        ctx.logger.info(`已执行指令：${command}`);
+      } catch (error) {
+        ctx.logger.error(`执行指令<${command.toString()}>时出错: ${error}`)
+      }
+      }
     }
 
     let sentencesCopy = [...sentences];
@@ -305,7 +324,11 @@ export function apply(ctx: Context, config: Config) {
         }
       });
       if (config.Debug.DebugAsInfo) { ctx.logger.info(sentence); }
-      await session.sendQueued(sentence);
+
+      // 按照字数等待
+      const waitTime = Math.ceil(sentence.length / config.Bot.WordsPerSecond);
+      await new Promise((resolve) => setTimeout(resolve, waitTime * 1000));
+      await session.bot.sendMessage(finalReplyTo, sentence);
     }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,14 +301,14 @@ export function apply(ctx: Context, config: Config) {
 
     // 如果 AI 使用了指令
     if (handledRes.LLMResponse.execute) {
-      for (const command of handledRes.LLMResponse.execute) {
-      try {
-        await session.bot.sendMessage(finalReplyTo, h("execute", {}, command)); // 执行每个指令
-        ctx.logger.info(`已执行指令：${command}`);
-      } catch (error) {
-        ctx.logger.error(`执行指令<${command.toString()}>时出错: ${error}`)
-      }
-      }
+      handledRes.LLMResponse.execute.forEach(async (command) => {
+        try {
+          await session.bot.sendMessage(finalReplyTo, h("execute", {}, command)); // 执行每个指令
+          ctx.logger.info(`已执行指令：${command}`);
+        } catch (error) {
+          ctx.logger.error(`执行指令<${command.toString()}>时出错: ${error}`)
+        }
+      });
     }
 
     let sentencesCopy = [...sentences];

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -187,3 +187,52 @@ export function calculateCosineSimilarity(vec1: number[], vec2: number[]): numbe
   const cosineSimilarity = dotProduct / (magnitude1 * magnitude2);
   return (cosineSimilarity + 1) / 2; // Transform from [-1, 1] to [0, 1]
 }
+
+// 检查群组是否在允许的群组组合列表中，并返回首个匹配到的群组组合配置或者所有匹配到的群组组合配置
+export function isGroupAllowed(groupId: string, allowedGroups: string[], debug: boolean = false): [boolean, Set<string>] {
+  const isPrivate = groupId.startsWith("private:");
+  const matchedGroups = new Set<string>();
+
+  // 遍历每个allowedGroups元素
+  for (const groupConfig of allowedGroups) {
+    // 使用Set去重
+    const groups = new Set(
+      groupConfig.split(",")
+        .map(g => g.trim())
+        .filter(g => g)  // 移除空字符串
+    );
+
+    for (const group of groups) {
+      // 检查全局允许
+      if (!isPrivate && group === "all") {
+        if (debug) {
+          matchedGroups.add(groupConfig);
+        } else {
+          return [true, groups];
+        }
+      }
+      // 检查全局私聊允许
+      if (isPrivate && group === "private:all") {
+        if (debug) {
+          matchedGroups.add(groupConfig);
+        } else {
+          return [true, groups];
+        }
+      }
+      // 精确匹配
+      if (groupId === group) {
+        if (debug) {
+          matchedGroups.add(groupConfig);
+        } else {
+          return [true, groups];
+        }
+      }
+    }
+  }
+
+  if (debug && matchedGroups.size > 0) {
+    return [true, matchedGroups];
+  }
+
+  return [false, new Set()];
+}

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -34,11 +34,11 @@ export default {
     ],
   },
   Bot: {
-    NickorName: "用户昵称"
+    NickorName: "用户昵称",
+    WordsPerSecond: 2,
   },
   Debug: {
     DebugAsInfo: false,
-    DisableGroupFilter: true,
     AllowErrorFormat: true,
     UpdatePromptOnLoad: false,
   },


### PR DESCRIPTION
- 修改了prompt的构建机制，在Group.AllowedGroup中可填写多个会话（群聊/私聊）id，bot的记忆将为同一槽位中所有会话的混合。这意味着可以做到：私聊bot，怂恿它在某群干某事；在群里聊的话题，在私聊时不遗忘。
- 为Group.AllowedGroup添加了`all`和`private:all`分别用于指定所有群聊和所有私聊。因此删除了`Debug.DisableGroupFilter`配置项。
- 为消息添加时间戳和会话id
- 自定义bot的打字速度
- 清除记忆指令仍按照会话id清除
- Group.TriggerCount、Group.MaxPopNum、Group.MinPopNum仍按照会话id应用
- Group.SendQueueSize同时作用于涉及到的单个会话id和记忆槽位，但只有单个会话id的消息达到此值时，会强制触发一次调用LLM，并删除更旧的消息。记忆槽位的总消息数达到此值时，更旧的消息不会被构筑入prompt中，但它们仍然保存着。
- 现在，发送给LLM的一条消息格式如下：
```
{
        time: "",  // 时间戳，格式为yyyy/mm/dd/hh/min/sec
        session_id: "",  // 此消息所在的会话id，示例："123456789"，"private:9876543210"
        id: "",  // 消息id，bot在需要引用消息时，用它来确定在select中填写的值
        author: "",  // 消息发送者的名字
        author_id: "",  // 消息发送者的id
        msg: "",  // 消息本体
}
```
- 现在，我们期望从LLM收到这样格式的消息：
```
{
      "status": "success", // "success" 或 "skip" (跳过回复)
      "session_id": "123456789", // 要把finReply发送到的会话id
      "logic": "", // LLM思考过程
      "select": "-1", // 回复引用的消息id
      "reply": "", // 初版回复
      "check": "", // 检查初版回复是否符合 "消息生成条例" 过程中的检查逻辑。
      "finReply": "" // 最终版回复
      "execute":[] // 要运行的指令列表
}
```
- 消息的目的地优先根据select所确定的消息id所在的会话确定，其次使用session_id确定
- 新增一个配置项Debug.FirsttoAll，启用时会更改记忆槽位的行为