### PR TITLE
[fix & feat] 修复根据消息id获取消息所在群id函数

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -5,10 +5,10 @@ import { Config } from "../config";
 
 interface Response {
   status: "skip" | "success";
-  session_id: string;
+  session_id: string | number;
   logic: string;
   reply: string;
-  select: number;
+  select: string | number;
   check: string;
   finReply: string;
   execute: Array<string>;
@@ -22,6 +22,20 @@ interface Usage {
 
 function correctInvalidFormat(str: string) {
    throw new Error("Not implemented");
+}
+
+function convertStringToNumber(value: string | number): number {
+  const num = typeof value === 'number' ? value : Number(value);
+  if (isNaN(num)) {
+    throw new Error(`Invalid number value: ${value}`);
+  }
+  return num;
+}
+function convertNumberToString(value: number | string): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return value.toString();
 }
 
 export abstract class BaseAdapter {
@@ -160,7 +174,7 @@ export abstract class BaseAdapter {
     res: string;
     resNoTag: string;
     replyTo: string;
-    quote: number;
+    quote: string;
     LLMResponse: any;
     usage?: Usage;
   }> {
@@ -250,9 +264,9 @@ export abstract class BaseAdapter {
     let finalResponseNoTag = finalResponse;
 
     // 添加引用消息在finalResponse的开头
-    if (~LLMResponse.select)
+    if (convertStringToNumber(LLMResponse.select) !== -1)
       finalResponse = h("quote", {
-        id: LLMResponse.select,
+        id: convertNumberToString(LLMResponse.select),
       }) + finalResponse;
 
     // 使用 groupMemberList 反转义 <at> 消息
@@ -295,8 +309,8 @@ export abstract class BaseAdapter {
     return {
       res: finalResponse,
       resNoTag: finalResponseNoTag,
-      replyTo: LLMResponse.session_id,
-      quote: LLMResponse.select,
+      replyTo: convertNumberToString(LLMResponse.session_id),
+      quote: convertNumberToString(LLMResponse.select),
       LLMResponse: LLMResponse,
       usage: usage,
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,6 +96,8 @@ export interface Config {
     };
     DebugAsInfo: boolean;
     FirsttoAll: boolean;
+    AddAllMsgtoQueue: boolean;
+    WholetoSplit: boolean;
     UpdatePromptOnLoad: boolean;
     AllowErrorFormat: boolean;
   };
@@ -415,6 +417,12 @@ export const Config: Schema<Config> = Schema.object({
     FirsttoAll: Schema.boolean()
       .default(false)
       .description("记忆槽位的行为改为：如果多个槽位都包含同一群号，所有包含该群号的槽位都将被应用"),
+    AddAllMsgtoQueue: Schema.boolean()
+      .default(false)
+      .description("将所有消息添加到消息队列，即使它们不是由 LLM 生成的"),
+    WholetoSplit: Schema.boolean()
+      .default(false)
+      .description("BOT的消息是否按照实际的分条存入消息队列，关闭表示一次调用API的消息在消息队列中会呈现为一条，开启表示按照实际发送的分条存入消息队列"),
     UpdatePromptOnLoad: Schema.boolean()
       .default(true)
       .description("每次启动时尝试更新 Prompt 文件"),

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -89,7 +89,7 @@ export async function getBotName(config: Config, session: any): Promise<string> 
     default:
       return config.Bot.BotName;
     case "群昵称":
-      const groupMember = session.groupMemberList.data.find(
+      const groupMember = session.groupMemberList?.data.find(
         (member: any) => member.user.id === session.event.selfId
       );
       return groupMember ? groupMember.nick : config.Bot.BotName;

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -114,7 +114,7 @@ export async function getMemberName(config: Config, session: any, byID?: string)
     return await getBotName(config, session);
   }
 
-  const member = session.groupMemberList.data.find(
+  const member = session.groupMemberList?.data.find(
     (member: any) => member.user.id === (byID || session.event.user.id)
   );
 

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -197,14 +197,15 @@ export class SendQueue {
   }
 
   // 根据消息id和群号字符串集合查找消息所在会话
-  findGroupByMessageId
-  (messageId: number, groups: Set<string>): string | null {
+  findGroupByMessageId(messageId: string, groups: Set<string>): string | null {
     for (const group of groups) {
       if (this.sendQueueMap.has(group)) {
         const queue = this.sendQueueMap.get(group);
-        for (const message of queue) {
-          if (message.id === messageId) {
-            return group;
+        if (queue) {
+          for (const message of queue) {
+            if (message.id === Number(messageId)) {
+              return group;
+            }
           }
         }
       }


### PR DESCRIPTION
- 修复 `findGroupByMessageId` 函数，此前它因为数据类型的关系无法正确工作
- 新增配置项 `Debug.AddAllMsgtoQueue`，开启时，所有来自 BOT 的消息（即使它不是通过LLM生成的）都会被添加到消息队列中，且用于触发指令的那一条消息也会被添加。换言之，开启这个选项后，BOT 会像正常人类一样看到所有的消息。
- 新增配置项 `Debug.WholetoSplit`，默认情况下，用 LLM 生成一次消息，即使它可能是分多条发送的，但在消息队列中它是作为一个整体只占一条消息。启用此项，分多条发送的情况下，也分条存储在消息队列中