### PR TITLE
[fix & feat & tweak] 让 BOT 自行控制发言频率

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Group:
     SendQueueSize: 100
     # 机器人在每个会话开始发言所需的消息数量，即首次触发条数
     TriggerCount: 2
-    # 以下是每次机器人发送消息后的冷却条数取随机数的区间
+    # 以下是每次机器人发送消息后的冷却条数由LLM确定或取随机数的区间
     # 最大冷却条数
     MaxPopNum: 4
     # 最小冷却条数
@@ -188,11 +188,11 @@ ${curGroupName} -> 触发此次调用的消息所在会话的名字。如果是�
 {
       "status": "success", // "success" 或 "skip" (跳过回复)
       "session_id": "123456789", // 要把finReply发送到的会话id
+      "nextReplyIn": 2, // 下次回复的冷却条数，让LLM参与控制发言频率
       "logic": "", // LLM思考过程
-      "select": "-1", // 回复引用的消息id
       "reply": "", // 初版回复
       "check": "", // 检查初版回复是否符合 "消息生成条例" 过程中的检查逻辑。
-      "finReply": "", // 最终版回复
+      "finReply": "", // 最终版回复，让LLM在开头添加<quote id=""/>来指定引用回复的消息id
       "execute":[] // 要运行的指令列表
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,11 +204,6 @@ export const Config: Schema<Config> = Schema.object({
     )
       .default([
         { key: "do_sample", value: "true" },
-        {
-          key: "grammar_string",
-          value:
-            'root   ::= object\nobject ::= "{\\n\\"status\\": " status-value ",\\n\\"logic\\": " logic-value ",\\n\\"select\\": " select-value ",\\n\\"reply\\": " reply-value ",\\n\\"check\\": " check-value ",\\n\\"finReply\\": " finReply-value ",\\n\\"execute\\": " execute-value "\\n}"\nstring ::= "\\"" ([^"\\\\] | "\\\\" ["\\\\/bfnrt])* "\\""\nnumber ::= [0-9]+\nban-time ::= [1-9][0-9]{1,3} | [1-4][0-3][0-1][0-9][0-9]\nstatus-value  ::= "\\"success\\"" | "\\"skip\\""\nlogic-value   ::= string | "\\"\\""\nselect-value  ::= number | "-1"\nreply-value   ::= string\ncheck-value   ::= "\\"\\""\nfinReply-value::= string\nexecute-value ::= "["( execute-cmds (", " execute-cmds )* )? "]"\nexecute-cmds  ::= delmsg | ban | reaction\ndelmsg        ::= "\\"delmsg " number "\\""\nban           ::= "\\"ban " number " " ban-time "\\""\nreaction      ::= "\\"reaction-create " number " " number "\\""',
-        },
       ])
       .role("table")
       .description("自定义请求体中的其他参数。有些api可能包含一些特别有用的功能，例如 dry_base 和 response_format。\n如果在调用api时出现400或422错误，请尝试删除此处的自定义参数。\n提示：直接将gbnf内容作为grammar_string的值粘贴至此时，换行符会被转换成空格，需要手动替换为\\n后方可生效"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,6 @@ export function apply(ctx: Context, config: Config) {
       const waitTime = Math.ceil(sentence.length / config.Bot.WordsPerSecond);
       await new Promise((resolve) => setTimeout(resolve, waitTime * 1000));
       finalBotMsgId = (await session.bot.sendMessage(finalReplyTo, sentence))[0];
-      ctx.logger.info(`已发送消息：${finalBotMsgId}`);
       if (config.Debug.WholetoSplit) {
         sendQueue.updateSendQueue(
           finalReplyTo,

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -154,21 +154,26 @@ export class SendQueue {
     return totalLength >= size;
   }
 
-  // 检查与重置触发计数
-  checkTriggerCount(group: string, nextTriggerCount: number, isAtMentioned: boolean): boolean {
+  // 检查触发计数
+  checkTriggerCount(group: string): boolean {
     if (this.triggerCountMap.has(group)) {
       const count = this.triggerCountMap.get(group);
       console.log(`距离下一次触发还有: ${count} 条消息`);
       if (count <= 0) {
-        this.triggerCountMap.set(group, nextTriggerCount);
-        this.saveToFile();
         return true;
       }
-      if (isAtMentioned) {
-        this.triggerCountMap.set(group, nextTriggerCount);
-        this.saveToFile();
-      }
       return false;
+    }
+    return false;
+  }
+
+  // 重置触发计数
+  resetTriggerCount(group: string, nextTriggerCount: number):boolean {
+    if (this.triggerCountMap.has(group)) {
+      this.triggerCountMap.set(group, nextTriggerCount);
+      this.saveToFile();
+      console.log(`已设置下一次触发计数为 ${nextTriggerCount}`);
+      return true;
     }
     return false;
   }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -126,7 +126,7 @@ class Test {
   }
 
   test() {
-    
+
     // 依次测试每个适配器, 保证能正确处理 ai 消息
     it("适配器解析", async () => {
       await this.client.shouldReply(`<at id="${this.client.bot.selfId}" name="" /> 你好`);
@@ -209,7 +209,7 @@ class Test {
       const content = JSON.stringify({
         "status": "success",
         "logic": "",
-        "select": -1,
+        "nextReplyIn": "",
         "reply": "",
         "check": "", //
         "finReply": "",


### PR DESCRIPTION
- 移除了响应JSON中的select，改为让LLM自己在finReply最前面添加`<quote id=""/>`标签
- 引用回复标签现在会进入上下文了
- BOT 发送的消息id现在正确了，不再为0。分条消息在队列中合并存储（默认情况）时，消息id为最后一分条消息的id
- 响应JSON中新增nextReplyIn项，整数，用来让 BOT 自己确定下一条消息的冷却条数，达到自适应发言频率的目的。此项仍然会满足在minPopNum和maxPopNum之间
- 下一条消息的冷却条数的随机范围从 `[minPopNum, maxPopNum)` 改为 `[minPopNum, maxPopNum]`
- 移除默认的gbnf参数 ~~因为在每次修改响应JSON之后还要对应修改这个默认参数很麻烦(ノω<。)ノ))☆.。~~
- 刷新冷却条数的时机从 `isTriggerReached || isAtMentioned` 改为 ` 生成完回复就刷新冷却条数`，这意味着at消息如果没能触发回复，不再会刷新冷却条数