### PR TITLE
[fix] 修复了一些已知问题

### DIFF
--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -203,6 +203,9 @@ export class SendQueue {
 
   // 根据消息id和群号字符串集合查找消息所在会话
   findGroupByMessageId(messageId: string, groups: Set<string>): string | null {
+    if (messageId.trim() === '') {
+      return null;
+    }
     for (const group of groups) {
       if (this.sendQueueMap.has(group)) {
         const queue = this.sendQueueMap.get(group);


### PR DESCRIPTION
- 修复当 `Debug.AddAllMsgtoQueue` 开启时，手动使用BOT账号发送私聊消息不被添加进消息队列的问题
- 修复消息目的地在 LLM 没有指定引用回复消息时不遵从指定 `session_id`，而遵从记忆槽位的最后一个会话id的问题