### PR TITLE
[fix] LLM 选择跳过回复时，有一行报错

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -2,6 +2,7 @@ import { h } from "koishi";
 import JSON5 from "json5";
 import { emojiManager } from "../utils/content";
 import { Config } from "../config";
+import { stat } from "fs";
 
 interface Response {
   status: "skip" | "success";
@@ -21,7 +22,9 @@ interface Usage {
 }
 
 function correctInvalidFormat(str: string) {
-   throw new Error("Not implemented");
+   return str.replace(/[\u0080-\uffff]/g, function(ch) {
+     return "\\u" + ("0000" + ch.charCodeAt(0).toString(16)).slice(-4);
+   });
 }
 
 function convertStringToNumber(value?: string | number ): number {
@@ -178,12 +181,16 @@ export abstract class BaseAdapter {
     config: Config,
     groupMemberList: any,
   ): Promise<{
-    res: string;
-    resNoTag: string;
-    replyTo: string;
-    quote: string;
-    nextTriggerCount: number;
-    LLMResponse: any;
+    status: string; // status, if fail, "fail"
+    originalRes: string; // res
+    res: string; // finReply || reply
+    resNoTag: string; // (finReply || reply).removeTag
+    resNoTagExceptQuote: string; // (finReply || reply).removeTagExceptQuote
+    replyTo: string; // session_id
+    quote: string; // extract from (finReply || reply)
+    nextTriggerCount: number; // nextReplyIn
+    logic: string; // logic
+    execute: Array<string>; // execute
     usage?: Usage;
   }> {
     let usage: any;
@@ -213,6 +220,7 @@ export abstract class BaseAdapter {
         break;
       }
       default: {
+        res = `不支持的 API 类型: ${this.adapterName}`
         throw new Error(`不支持的 API 类型: ${this.adapterName}`);
       }
     }
@@ -231,31 +239,37 @@ export abstract class BaseAdapter {
     //   "finReply": "" // 最终版回复，引用回复<quote id=\\"\\"/>由 LLM 生成，转义和双引号一定要带
     //   "execute":[] // 要运行的指令列表
     // }
+
+    let status: string = "success";
+    let finalResponse: string = "";
+
     const jsonMatch = res.match(/{.*}/s);
     let LLMResponse: Response;
     if (jsonMatch) {
-      res = jsonMatch[0];
-      LLMResponse = JSON5.parse(res);
-    } else {
-      throw new Error(`LLM provides unexpected response: ${res}`);
-    }
-    if (LLMResponse.status != "success") {
-      if (!AllowErrorFormat && LLMResponse.status != "skip") {
-        throw new Error(`LLM provides unexpected response: ${res}`);
-      } else {
-        console.log(`LLM choose not to reply.`);
+      try {
+        const resJSON = jsonMatch[0];
+        LLMResponse = JSON5.parse(correctInvalidFormat(resJSON));
+      } catch (e) {
+        status = "fail";
       }
-    }
-    let finalResponse: string = "";
-    if (!AllowErrorFormat) {
-      finalResponse += LLMResponse.finReply
-        ? LLMResponse.finReply
-        : LLMResponse.reply;
     } else {
+      status = "fail";
+    }
+    if (LLMResponse.status === "success" || LLMResponse.status === "skip"){
+      status = LLMResponse.status;
+    } else {
+      status = "fail";
+    }
+    if (!AllowErrorFormat) {
+      try {
+        finalResponse += LLMResponse.finReply || LLMResponse.reply;
+      } catch (e) {
+        status = "fail";
+      }
+    } else {
+      finalResponse += LLMResponse.finReply || LLMResponse.reply || "";
       // 盗版回复
       const possibleResponse = [
-        LLMResponse.finReply,
-        LLMResponse.reply,
         //@ts-ignore
         LLMResponse.msg, LLMResponse.text, LLMResponse.message, LLMResponse.answer
       ];
@@ -265,27 +279,24 @@ export abstract class BaseAdapter {
           break;
         }
       }
-      if (finalResponse === "" && !LLMResponse.execute?.length) throw new Error(`LLM provides unexpected response: ${res}`);
     }
 
     // 从回复中提取 <quote> 标签，将其放在回复的最前面
     const quoteMatch = finalResponse.match(/<quote\s+id=\\*["']?(\d+)\\*["']?\s*\/?>/);
+    let finalResponseNoTag = finalResponse;
     if (quoteMatch) {
       // 移除所有的 <quote> 标签
       finalResponse = finalResponse.replace(/<quote\s+id=\\*["']?\d+\\*["']?\s*\/?>/g, '');
+      finalResponseNoTag = finalResponse.replace(/<quote\s+id=\\*["']?\d+\\*["']?\s*\/?>/g, `[引用回复: ${quoteMatch[1]}]`);
       // 把第一个 <quote> 标签放在回复的最前面
       finalResponse = h("quote", { id: quoteMatch[1] }) + finalResponse;
     }
 
-    // 复制一份finalResonse为finalResponseNoTag，作为添加到队列中的bot消息内容
-    let finalResponseNoTag = finalResponse; // 这里让finalResponseNoTag中包含<quote>标签，是故意的
+    // 复制一份finalResonse为finalResponseNoTagExceptQuote，作为添加到队列中的bot消息内容
+    let finalResponseNoTagExceptQuote = finalResponse;
 
     // 使用 groupMemberList 反转义 <at> 消息
     // const groupMemberList: { nick: string; user: { name: string; id: string } }[] =  groupMemberList.data;
-
-    if (!["群昵称", "用户昵称"].includes(config.Bot.NickorName)) {
-      throw new Error(`Unsupported NickorName value: ${config.Bot.NickorName}`);
-    }
 
     const getKey = (member: { nick: string; user: { name: string } }) => config.Bot.NickorName === "群昵称" ? member.nick : member.user.name;
 
@@ -318,12 +329,16 @@ export abstract class BaseAdapter {
     });
 
     return {
+      status: status,
+      originalRes: res,
       res: finalResponse,
+      resNoTagExceptQuote: finalResponseNoTagExceptQuote,
       resNoTag: finalResponseNoTag,
       replyTo: convertNumberToString(LLMResponse.session_id),
       quote: quoteMatch ? quoteMatch[1] : '',
       nextTriggerCount: convertStringToNumber(LLMResponse.nextReplyIn),
-      LLMResponse: LLMResponse,
+      logic: LLMResponse.logic || '',
+      execute: LLMResponse.execute || [],
       usage: usage,
     };
   }

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -287,9 +287,10 @@ export abstract class BaseAdapter {
     if (quoteMatch) {
       // 移除所有的 <quote> 标签
       finalResponse = finalResponse.replace(/<quote\s+id=\\*["']?\d+\\*["']?\s*\/?>/g, '');
-      finalResponseNoTag = finalResponse.replace(/<quote\s+id=\\*["']?\d+\\*["']?\s*\/?>/g, `[引用回复: ${quoteMatch[1]}]`);
+      finalResponseNoTag = finalResponse;
       // 把第一个 <quote> 标签放在回复的最前面
       finalResponse = h("quote", { id: quoteMatch[1] }) + finalResponse;
+      finalResponseNoTag = `[引用回复: ${quoteMatch[1]}]\n` + finalResponseNoTag;
     }
 
     // 复制一份finalResonse为finalResponseNoTagExceptQuote，作为添加到队列中的bot消息内容

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,12 +230,16 @@ export function apply(ctx: Context, config: Config) {
       ctx.logger.info(JSON5.stringify(response, null, 2));
 
     const handledRes: {
+      status: string;
+      originalRes: string;
       res: string;
       resNoTag: string;
+      resNoTagExceptQuote: string;
       replyTo: string;
       quote: string;
       nextTriggerCount: number;
-      LLMResponse: any;
+      logic: string;
+      execute: Array<string>;
       usage?: any;
     } = await adapters[curAPI].handleResponse(
       response,
@@ -271,27 +275,57 @@ export function apply(ctx: Context, config: Config) {
       finalReplyTo = quoteGroup;
     }
 
+    if (handledRes.status === "fail") {
+      if (config.Debug.LogicRedirect.Enabled) {
+        const failTemplate = `LLM 的响应无法正确解析。
+原始响应:
+${handledRes.originalRes}
+---
+消耗: 输入 ${handledRes?.usage?.prompt_tokens}, 输出 ${handledRes?.usage?.completion_tokens}`;
+        const botMessageId = (await session.bot.sendMessage(config.Debug.LogicRedirect.Target, failTemplate))[0];
+        if (config.Debug.AddAllMsgtoQueue) {
+          sendQueue.updateSendQueue(
+            config.Debug.LogicRedirect.Target,
+            await getBotName(config, session),
+            session.event.selfId,
+            failTemplate,
+            botMessageId,
+            config.Group.Filter,
+            config.Group.TriggerCount,
+            session.event.selfId
+          )
+        }
+      }
+      throw new Error(`LLM provides unexpected response:
+${handledRes.originalRes}`);
+    }
+
     if (config.Debug.LogicRedirect.Enabled) {
-      const template = `回复于 ${finalReplyTo} 的消息已生成，来自 API ${curAPI}:
-内容: ${(handledRes.LLMResponse.finReply ? handledRes.LLMResponse.finReply : handledRes.LLMResponse.reply)}
+      const template = `${handledRes.status === "skip" ? `${await getBotName(config, session)}想要跳过此次回复` : `回复于 ${finalReplyTo} 的消息已生成，来自 API ${curAPI}:
+状态: ${handledRes.status}`}
 ---
-逻辑: ${handledRes.LLMResponse.logic}
+内容: ${handledRes.res && handledRes.res.trim() ? handledRes.res : "无"}
 ---
-指令：${handledRes.LLMResponse.execute ? handledRes.LLMResponse.execute : "无"}
+逻辑: ${handledRes.logic}
 ---
-消耗: 输入 ${handledRes?.usage["prompt_tokens"]}, 输出 ${handledRes?.usage["completion_tokens"]}`;
+指令：${handledRes.execute?.length ? handledRes.execute : "无"}
+---
+消耗: 输入 ${handledRes?.usage?.prompt_tokens}, 输出 ${handledRes?.usage?.completion_tokens}`;
+// 有时候 LLM 就算跳过回复，也会生成内容，这个时候应该无视跳过，发送内容
+// 有时候 LLM 会生成空内容，这个时候就算是success也不应该发送内容，但是如果有执行指令，应该执行
+      const templateNoTag = template.replace(handledRes.res, handledRes.resNoTag);
       const botMessageId = (await session.bot.sendMessage(config.Debug.LogicRedirect.Target, template))[0];
       if (config.Debug.AddAllMsgtoQueue) {
-        sendQueue.updateSendQueue(
-          config.Debug.LogicRedirect.Target,
-          await getBotName(config, session),
-          session.event.selfId,
-          template,
-          botMessageId,
-          config.Group.Filter,
-          config.Group.TriggerCount,
-          session.event.selfId
-        )
+      sendQueue.updateSendQueue(
+        config.Debug.LogicRedirect.Target,
+        await getBotName(config, session),
+        session.event.selfId,
+        templateNoTag,
+        botMessageId,
+        config.Group.Filter,
+        config.Group.TriggerCount,
+        session.event.selfId
+      );
       }
     }
 
@@ -311,13 +345,13 @@ export function apply(ctx: Context, config: Config) {
     responseVerifier.setPreviousResponse(finalRes);
 
     const sentences = finalRes.split(/(?<=[。?!？！])\s*/);
-    const sentencesNoTag = handledRes.resNoTag.split(/(?<=[。?!？！])\s*/);
+    const sentencesNoTag = handledRes.resNoTagExceptQuote.split(/(?<=[。?!？！])\s*/);
 
 
 
     // 如果 AI 使用了指令
-    if (handledRes.LLMResponse.execute) {
-      handledRes.LLMResponse.execute.forEach(async (command) => {
+    if (handledRes.execute) {
+      handledRes.execute.forEach(async (command) => {
         try {
           const botMessageId = (await session.bot.sendMessage(finalReplyTo, h("execute", {}, command)))[0]; // 执行每个指令，获取返回的消息ID字符串数组
           if (config.Debug.AddAllMsgtoQueue) {
@@ -378,7 +412,7 @@ export function apply(ctx: Context, config: Config) {
         finalReplyTo,
         await getBotName(config, session),
         session.event.selfId,
-        handledRes.resNoTag,
+        handledRes.resNoTagExceptQuote,
         finalBotMsgId, // session.messageId，这里是机器人自己发的消息，设为最后一条消息的消息ID
         config.Group.Filter,
         config.Group.TriggerCount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,7 @@ ${handledRes.originalRes}`);
 // 有时候 LLM 就算跳过回复，也会生成内容，这个时候应该无视跳过，发送内容
 // 有时候 LLM 会生成空内容，这个时候就算是success也不应该发送内容，但是如果有执行指令，应该执行
       const templateNoTag = template.replace(handledRes.res, handledRes.resNoTag);
-      const botMessageId = (await session.bot.sendMessage(config.Debug.LogicRedirect.Target, template))[0];
+      const botMessageId = (await session.bot.sendMessage(config.Debug.LogicRedirect.Target, templateNoTag))[0];
       if (config.Debug.AddAllMsgtoQueue) {
       sendQueue.updateSendQueue(
         config.Debug.LogicRedirect.Target,


### PR DESCRIPTION
- 当 `config.Debug.LogicRedirect.Enabled` 为 `true` 时，无论 LLM 的响应如何（成功 | 跳过 | 无法解析），都会给予用户反馈，现在你可以更容易地知道为什么 LLM 选择跳过回复了
- 移除了这条在 LLM 选择跳过时出现的不完整的报错: `at async Processor._handleMessage (E:\Koishi\dev\yesimbot\node_modules\@koishijs\core\src\middleware.ts:269:22)`，顺带解决了由于过早抛出错误导致的一些问题
- 当 `config.Debug.AddAllMsgtoQueue` 为 `true` 时，因 `config.Debug.LogicRedirect.Enabled` 而产生的消息在进入消息队列和发送时，`<quote>` 标签会被转义成 `[引用回复: 消息id]\n`