### PR TITLE
[fix] 修复一些已知问题

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -96,7 +96,7 @@ export interface Config {
     };
     DebugAsInfo: boolean;
     FirsttoAll: boolean;
-    AddAllMsgtoQueue: boolean;
+    AddWhattoQueue: "所有消息" | "所有此插件发送和接收的消息" | "所有和LLM交互的消息";
     WholetoSplit: boolean;
     UpdatePromptOnLoad: boolean;
     AllowErrorFormat: boolean;
@@ -412,9 +412,13 @@ export const Config: Schema<Config> = Schema.object({
     FirsttoAll: Schema.boolean()
       .default(false)
       .description("记忆槽位的行为改为：如果多个槽位都包含同一群号，所有包含该群号的槽位都将被应用"),
-    AddAllMsgtoQueue: Schema.boolean()
-      .default(false)
-      .description("将所有消息添加到消息队列，即使它们不是由 LLM 生成的"),
+    AddWhattoQueue: Schema.union([
+      "所有消息",
+      "所有此插件发送和接收的消息",
+      "所有和LLM交互的消息",
+    ])
+      .default("所有和LLM交互的消息")
+      .description("将哪些消息添加到消息队列。选择“所有消息”时，将使用事件监听器来更新消息队列，请打开自身消息上报，这将导致WholetoSplit失效(始终以实际的分条存入消息队列)"),
     WholetoSplit: Schema.boolean()
       .default(false)
       .description("BOT的消息是否按照实际的分条存入消息队列，关闭表示一次调用API的消息在消息队列中会呈现为一条，开启表示按照实际发送的分条存入消息队列"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,7 +251,7 @@ export function apply(ctx: Context, config: Config) {
       response,
       config.Debug.AllowErrorFormat,
       config,
-      session.groupMemberList.datas
+      session.groupMemberList.data
     );
 
     const finalRes: string = handledRes.res;

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,6 +273,12 @@ export function apply(ctx: Context, config: Config) {
             : "Quote message not found, using session_id."
         );
       }
+      if (!finalReplyTo) {
+        finalReplyTo = groupId;
+        if (config.Debug.DebugAsInfo) {
+          ctx.logger.info(`There's no session_id, using ${groupId} Instead.`);
+        }
+      }
     } else {
       finalReplyTo = quoteGroup;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { ResponseVerifier } from "./utils/verifier";
 
 import { Config } from "./config";
 
-import { isGroupAllowed } from "./utils/tools";
+import { isGroupAllowed, foldText } from "./utils/tools";
 
 import { genSysPrompt, ensurePromptFileExists, getMemberName, getBotName } from "./utils/prompt";
 
@@ -135,7 +135,7 @@ export function apply(ctx: Context, config: Config) {
     session.guildName = `${session.bot.user.name}与${session.event.user.name}的私聊`;
 
     if (config.Debug.DebugAsInfo)
-      ctx.logger.info(`New message received, guildId = ${groupId}, content = ${session.content}`);
+      ctx.logger.info(`New message received, guildId = ${groupId}, content = ${foldText(session.content, 1000)}`);
 
     if (!config.Group.AllowedGroups?.length) return next();
 
@@ -182,7 +182,7 @@ export function apply(ctx: Context, config: Config) {
 
     if (!isTriggerCountReached && !(isAtMentioned && shouldReactToAt)) {
       if (config.Debug.DebugAsInfo)
-        ctx.logger.info(await sendQueue.getPrompt(mergeQueueFrom, config, session));
+        ctx.logger.info(foldText((await sendQueue.getPrompt(mergeQueueFrom, config, session)), 2048));
       return next();
     }
 
@@ -229,7 +229,7 @@ export function apply(ctx: Context, config: Config) {
     );
 
     if (config.Debug.DebugAsInfo)
-      ctx.logger.info(JSON5.stringify(response, null, 2));
+      ctx.logger.info(foldText(JSON5.stringify(response, null, 2), 3500));
 
     const handledRes: {
       status: string;
@@ -396,7 +396,7 @@ ${handledRes.originalRes}`);
           sentenceNoTag = sentenceNoTag.replace(regex, rule.tothis);
         }
       });
-      if (config.Debug.DebugAsInfo) { ctx.logger.info(sentence); }
+      if (config.Debug.DebugAsInfo) { ctx.logger.info(foldText(sentence, 1000)); }
 
       // 按照字数等待
       const waitTime = Math.ceil(sentence.length / config.Bot.WordsPerSecond);

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,7 +426,26 @@ ${handledRes.originalRes}`);
 
       // 过滤空字符串并去除首尾空格
       const sentences = result.filter(s => s.trim()).map(s => s.trim());
-      return sentences;
+
+      // 合并标签前后的文本
+      const mergedSentences: string[] = [];
+      for (let i = 0; i < sentences.length; i++) {
+        if (sentences[i].startsWith('<') && sentences[i].endsWith('>')) {
+          if (i > 0) {
+            mergedSentences[mergedSentences.length - 1] += sentences[i];
+          } else {
+            mergedSentences.push(sentences[i]);
+          }
+          if (i < sentences.length - 1 && !sentences[i + 1].startsWith('<')) {
+            mergedSentences[mergedSentences.length - 1] += sentences[i + 1];
+            i++;
+          }
+        } else {
+          mergedSentences.push(sentences[i]);
+        }
+      }
+
+      return mergedSentences;
     };
 
     const sentences = splitByTags(finalRes);

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,38 +365,38 @@ ${handledRes.originalRes}`);
       let i = 0;
 
       while (i < text.length) {
-      if (text[i] === '<') {
-        // 找到标签的开始
-        let tagEnd = text.indexOf('>', i);
-        if (tagEnd === -1) break;
+        if (text[i] === '<') {
+          // 找到标签的开始
+          let tagEnd = text.indexOf('>', i);
+          if (tagEnd === -1) break;
 
-        let tag = text.substring(i + 1, tagEnd);
-        if (tag.startsWith('/')) {
-        // 处理结束标签
-        const openTag = stack.pop();
-        if (openTag) {
-          splits.push({
-          text: text.substring(openTag.start, tagEnd + 1),
-          start: openTag.start,
-          end: tagEnd + 1
-          });
-        }
-        } else if (tag.endsWith('/')) {
-        // 处理自闭合标签
-        splits.push({
-          text: text.substring(i, tagEnd + 1),
-          start: i,
-          end: tagEnd + 1
-        });
+          let tag = text.substring(i + 1, tagEnd);
+          if (tag.startsWith('/')) {
+            // 处理结束标签
+            const openTag = stack.pop();
+            if (openTag) {
+              splits.push({
+                text: text.substring(openTag.start, tagEnd + 1),
+                start: openTag.start,
+                end: tagEnd + 1
+              });
+            }
+          } else if (tag.endsWith('/')) {
+            // 处理自闭合标签
+            splits.push({
+              text: text.substring(i, tagEnd + 1),
+              start: i,
+              end: tagEnd + 1
+            });
+          } else {
+            // 处理开始标签
+            stack.push({ tag, start: i });
+          }
+          i = tagEnd + 1;
         } else {
-        // 处理开始标签
-        stack.push({ tag, start: i });
+          currentText += text[i];
+          i++;
         }
-        i = tagEnd + 1;
-      } else {
-        currentText += text[i];
-        i++;
-      }
       }
 
       // 按标点符号分割剩余文本
@@ -407,20 +407,20 @@ ${handledRes.originalRes}`);
       splits.sort((a, b) => a.start - b.start);
 
       for (const split of splits) {
-      // 添加标签前的文本
-      const beforeTag = text.substring(lastEnd, split.start);
-      if (beforeTag) {
-        result.push(...beforeTag.split(splitRegex));
-      }
-      // 将完整标签添加到结果中
-      result.push(split.text);
-      lastEnd = split.end;
+        // 添加标签前的文本
+        const beforeTag = text.substring(lastEnd, split.start);
+        if (beforeTag) {
+          result.push(...beforeTag.split(splitRegex));
+        }
+        // 将完整标签添加到结果中
+        result.push(split.text);
+        lastEnd = split.end;
       }
 
       // 添加最后一个标签后的剩余文本
       const afterLastTag = text.substring(lastEnd);
       if (afterLastTag) {
-      result.push(...afterLastTag.split(splitRegex));
+        result.push(...afterLastTag.split(splitRegex));
       }
 
       // 过滤空字符串
@@ -429,19 +429,19 @@ ${handledRes.originalRes}`);
       // 合并标签前后的文本
       const mergedSentences: string[] = [];
       for (let i = 0; i < sentences.length; i++) {
-      if (sentences[i].startsWith('<') && sentences[i].endsWith('>')) {
-        if (i > 0) {
-        mergedSentences[mergedSentences.length - 1] += sentences[i];
+        if (sentences[i].startsWith('<') && sentences[i].endsWith('>')) {
+          if (i > 0) {
+            mergedSentences[mergedSentences.length - 1] += sentences[i];
+          } else {
+            mergedSentences.push(sentences[i]);
+          }
+          if (i < sentences.length - 1 && !sentences[i + 1].startsWith('<')) {
+            mergedSentences[mergedSentences.length - 1] += sentences[i + 1];
+            i++;
+          }
         } else {
-        mergedSentences.push(sentences[i]);
+          mergedSentences.push(sentences[i]);
         }
-        if (i < sentences.length - 1 && !sentences[i + 1].startsWith('<')) {
-        mergedSentences[mergedSentences.length - 1] += sentences[i + 1];
-        i++;
-        }
-      } else {
-        mergedSentences.push(sentences[i]);
-      }
       }
 
       return mergedSentences;

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,8 +352,81 @@ ${handledRes.originalRes}`);
 
     responseVerifier.setPreviousResponse(finalRes);
 
-    const sentences = finalRes.split(/(?<=[。?!？！])\s*/);
-    const sentencesNoTag = handledRes.resNoTagExceptQuote.split(/(?<=[。?!？！])\s*/);
+    const splitByTags = (text: string): string[] => {
+      // 用于追踪标签的栈
+      const stack: { tag: string; start: number }[] = [];
+      // 存储分割后的文本片段
+      const splits: { text: string; start: number; end: number }[] = [];
+      const splitRegex = /(?<=[。?!？！])\s*/;
+      let currentText = '';
+      let i = 0;
+
+      while (i < text.length) {
+        if (text[i] === '<') {
+          // 找到标签的开始
+          let tagEnd = text.indexOf('>', i);
+          if (tagEnd === -1) break;
+
+          let tag = text.substring(i + 1, tagEnd);
+          if (tag.startsWith('/')) {
+            // 处理结束标签
+            const openTag = stack.pop();
+            if (openTag) {
+              splits.push({
+                text: text.substring(openTag.start, tagEnd + 1),
+                start: openTag.start,
+                end: tagEnd + 1
+              });
+            }
+          } else if (tag.endsWith('/')) {
+            // 处理自闭合标签
+            splits.push({
+              text: text.substring(i, tagEnd + 1),
+              start: i,
+              end: tagEnd + 1
+            });
+          } else {
+            // 处理开始标签
+            stack.push({ tag, start: i });
+          }
+          i = tagEnd + 1;
+        } else {
+          currentText += text[i];
+          i++;
+        }
+      }
+
+      // 按标点符号分割剩余文本
+      const result: string[] = [];
+      let lastEnd = 0;
+
+      // 按开始位置对分割进行排序
+      splits.sort((a, b) => a.start - b.start);
+
+      for (const split of splits) {
+        // 添加标签前的文本
+        const beforeTag = text.substring(lastEnd, split.start);
+        if (beforeTag) {
+          result.push(...beforeTag.split(splitRegex));
+        }
+        // 将完整标签添加到结果中
+        result.push(split.text);
+        lastEnd = split.end;
+      }
+
+      // 添加最后一个标签后的剩余文本
+      const afterLastTag = text.substring(lastEnd);
+      if (afterLastTag) {
+        result.push(...afterLastTag.split(splitRegex));
+      }
+
+      // 过滤空字符串并去除首尾空格
+      const sentences = result.filter(s => s.trim()).map(s => s.trim());
+      return sentences;
+    };
+
+    const sentences = splitByTags(finalRes);
+    const sentencesNoTag = splitByTags(handledRes.resNoTagExceptQuote);
 
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,38 +366,38 @@ ${handledRes.originalRes}`);
       let i = 0;
 
       while (i < text.length) {
-        if (text[i] === '<') {
-          // 找到标签的开始
-          let tagEnd = text.indexOf('>', i);
-          if (tagEnd === -1) break;
+      if (text[i] === '<') {
+        // 找到标签的开始
+        let tagEnd = text.indexOf('>', i);
+        if (tagEnd === -1) break;
 
-          let tag = text.substring(i + 1, tagEnd);
-          if (tag.startsWith('/')) {
-            // 处理结束标签
-            const openTag = stack.pop();
-            if (openTag) {
-              splits.push({
-                text: text.substring(openTag.start, tagEnd + 1),
-                start: openTag.start,
-                end: tagEnd + 1
-              });
-            }
-          } else if (tag.endsWith('/')) {
-            // 处理自闭合标签
-            splits.push({
-              text: text.substring(i, tagEnd + 1),
-              start: i,
-              end: tagEnd + 1
-            });
-          } else {
-            // 处理开始标签
-            stack.push({ tag, start: i });
-          }
-          i = tagEnd + 1;
-        } else {
-          currentText += text[i];
-          i++;
+        let tag = text.substring(i + 1, tagEnd);
+        if (tag.startsWith('/')) {
+        // 处理结束标签
+        const openTag = stack.pop();
+        if (openTag) {
+          splits.push({
+          text: text.substring(openTag.start, tagEnd + 1),
+          start: openTag.start,
+          end: tagEnd + 1
+          });
         }
+        } else if (tag.endsWith('/')) {
+        // 处理自闭合标签
+        splits.push({
+          text: text.substring(i, tagEnd + 1),
+          start: i,
+          end: tagEnd + 1
+        });
+        } else {
+        // 处理开始标签
+        stack.push({ tag, start: i });
+        }
+        i = tagEnd + 1;
+      } else {
+        currentText += text[i];
+        i++;
+      }
       }
 
       // 按标点符号分割剩余文本
@@ -408,41 +408,41 @@ ${handledRes.originalRes}`);
       splits.sort((a, b) => a.start - b.start);
 
       for (const split of splits) {
-        // 添加标签前的文本
-        const beforeTag = text.substring(lastEnd, split.start);
-        if (beforeTag) {
-          result.push(...beforeTag.split(splitRegex));
-        }
-        // 将完整标签添加到结果中
-        result.push(split.text);
-        lastEnd = split.end;
+      // 添加标签前的文本
+      const beforeTag = text.substring(lastEnd, split.start);
+      if (beforeTag) {
+        result.push(...beforeTag.split(splitRegex));
+      }
+      // 将完整标签添加到结果中
+      result.push(split.text);
+      lastEnd = split.end;
       }
 
       // 添加最后一个标签后的剩余文本
       const afterLastTag = text.substring(lastEnd);
       if (afterLastTag) {
-        result.push(...afterLastTag.split(splitRegex));
+      result.push(...afterLastTag.split(splitRegex));
       }
 
-      // 过滤空字符串并去除首尾空格
-      const sentences = result.filter(s => s.trim()).map(s => s.trim());
+      // 过滤空字符串
+      const sentences = result.filter(s => s.trim());
 
       // 合并标签前后的文本
       const mergedSentences: string[] = [];
       for (let i = 0; i < sentences.length; i++) {
-        if (sentences[i].startsWith('<') && sentences[i].endsWith('>')) {
-          if (i > 0) {
-            mergedSentences[mergedSentences.length - 1] += sentences[i];
-          } else {
-            mergedSentences.push(sentences[i]);
-          }
-          if (i < sentences.length - 1 && !sentences[i + 1].startsWith('<')) {
-            mergedSentences[mergedSentences.length - 1] += sentences[i + 1];
-            i++;
-          }
+      if (sentences[i].startsWith('<') && sentences[i].endsWith('>')) {
+        if (i > 0) {
+        mergedSentences[mergedSentences.length - 1] += sentences[i];
         } else {
-          mergedSentences.push(sentences[i]);
+        mergedSentences.push(sentences[i]);
         }
+        if (i < sentences.length - 1 && !sentences[i + 1].startsWith('<')) {
+        mergedSentences[mergedSentences.length - 1] += sentences[i + 1];
+        i++;
+        }
+      } else {
+        mergedSentences.push(sentences[i]);
+      }
       }
 
       return mergedSentences;

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,6 +1,4 @@
 import { getMemberName } from './prompt';
-import https from 'https';
-import axios from 'axios';
 import { readFileSync } from 'fs';
 import path from 'path';
 import JSON5 from "json5";

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,11 +1,11 @@
 import { getMemberName } from './prompt';
 import https from 'https';
 import axios from 'axios';
-import {readFileSync} from 'fs';
+import { readFileSync } from 'fs';
 import path from 'path';
 import JSON5 from "json5";
 import { replaceImageWith } from './image-viewer';
-import { runEmbedding, calculateCosineSimilarity } from './tools';
+import { runEmbedding, calculateCosineSimilarity, convertUrltoBase64 } from './tools';
 import { Config } from '../config';
 import { Session } from 'koishi';
 
@@ -53,22 +53,22 @@ class EmojiManager {
   private async initializeEmbeddings(config: Config): Promise<void> {
     const currentModel = config.Embedding?.EmbeddingModel;
     const needsRecompute =
-        Object.keys(this.nameEmbeddings).length === 0 ||
-        this.lastEmbeddingModel !== currentModel;
+      Object.keys(this.nameEmbeddings).length === 0 ||
+      this.lastEmbeddingModel !== currentModel;
 
     if (needsRecompute) {
-        // 清空现有嵌入
-        this.nameEmbeddings = {};
+      // 清空现有嵌入
+      this.nameEmbeddings = {};
 
-        const names = Object.values(this.idToName);
-        for (const name of names) {
-            this.nameEmbeddings[name] = await this.getEmbedding(name, config);
-        }
+      const names = Object.values(this.idToName);
+      for (const name of names) {
+        this.nameEmbeddings[name] = await this.getEmbedding(name, config);
+      }
 
-        // 更新已使用的模型记录
-        this.lastEmbeddingModel = currentModel;
+      // 更新已使用的模型记录
+      this.lastEmbeddingModel = currentModel;
     }
-}
+  }
 
   async getNameById(id: string): Promise<string | undefined> {
     return this.idToName[id];
@@ -140,44 +140,20 @@ export async function replaceTags(str: string, config: Config): Promise<string> 
     finalString = finalString.replace(match, replacement);
   });
 
-  // url 转 base64 添加到 img 标签中
   const imgMatches = Array.from(finalString.matchAll(imgRegex));
-  const imgReplacements = await Promise.all(imgMatches.map(async (match) => {
+  for (const match of imgMatches) {
     const [fullMatch, src] = match;
     const imageUrl = src.replace(/&amp;/g, '&');
-    try {
-      const response = await axios.get(imageUrl, {
-        responseType: 'arraybuffer',
-        httpsAgent: new https.Agent({ rejectUnauthorized: false }), // 忽略SSL证书验证
-        timeout: 5000  // 5秒超时
-      });
+    let replacement = fullMatch;
 
-      const buffer = Buffer.from(response.data);
-      const contentType = response.headers['content-type'] || 'image/jpeg';
-      const base64 = `data:${contentType};base64,${buffer.toString('base64')}`;
+    if (config.ImageViewer.How === 'LLM API 自带的多模态能力') {
+      const base64 = await convertUrltoBase64(imageUrl);
+      replacement = `<img base64="${base64}" src="${imageUrl}"/>`;
+    } else {
+      replacement = await replaceImageWith(fullMatch, config);
+    }
 
-      return {
-        match: fullMatch,
-        replacement: `<img base64="${base64}" src="${imageUrl}"/>`
-      };
-    } catch (error) {
-      console.error('Error converting image to base64:', error.message);
-      return {
-        match: fullMatch,
-        replacement: `<img src="${imageUrl}"/>`
-      };
-    }
-  }));
-
-  if (config.ImageViewer.How !== 'LLM API 自带的多模态能力') {
-    for (const { match, replacement } of imgReplacements) {
-      const newReplacement = await replaceImageWith(replacement, config);
-      finalString = finalString.replace(match, newReplacement);
-    }
-  } else {
-    for (const { match, replacement } of imgReplacements) {
-      finalString = finalString.replace(match, replacement);
-    }
+    finalString = finalString.replace(fullMatch, replacement);
   }
 
   finalString = finalString.replace(videoRegex, "[视频]");

--- a/src/utils/image-viewer.ts
+++ b/src/utils/image-viewer.ts
@@ -54,7 +54,8 @@ export async function replaceImageWith(imgTag: string, config: Config) {
 
     case "替换成[图片:summary]": {
       if (summaryMatch) {
-        return `[图片:${summaryMatch[1]}]`;
+        const summary = summaryMatch[1].replace(/^\[|\]$/g, '');
+        return `[图片:${summary}]`;
       } else {
         return "[图片]";
       }


### PR DESCRIPTION
- LLM 没有提供目标会话id时，默认使用当前会话id，避免直接报错
- 日志折叠，避免koishi崩溃
- 只有必要时才获取base64，避免不必要的图片下载
- 修复标签被句子分割打断的问题
- 修复打开自身消息上报时，一条回复在消息队列中添加两次的问题
- 修复api响应期间的消息无视触发计数而触发api调用的问题