### PR TITLE
[fix & feat] 时间相关功能

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -267,7 +267,7 @@ export abstract class BaseAdapter {
       status = "fail"; // status 不是 "success" 或 "skip"
     }
     if (!AllowErrorFormat) {
-      if (LLMResponse.finReply || LLMResponse.reply) {
+      if (LLMResponse.finReply || LLMResponse.reply || status === "skip") {
         finalResponse += LLMResponse.finReply || LLMResponse.reply || "";
       } else {
         status = "fail"; // 回复格式错误
@@ -285,6 +285,14 @@ export abstract class BaseAdapter {
           break;
         }
       }
+    }
+
+    let finalLogic: string = LLMResponse.logic || "";
+
+    const logicQuoteMatch = finalLogic.match(/<quote\s+id=\\*["']?(\d+)\\*["']?\s*\/?>/);
+    if (logicQuoteMatch) {
+      finalLogic = finalLogic.replace(/<quote\s+id=\\*["']?\d+\\*["']?\s*\/?>/g, '');
+      finalLogic = `[引用回复: ${logicQuoteMatch[1]}]\n` + finalLogic;
     }
 
     // 从回复中提取 <quote> 标签，将其放在回复的最前面
@@ -344,7 +352,7 @@ export abstract class BaseAdapter {
       replyTo: convertNumberToString(LLMResponse.session_id),
       quote: quoteMatch ? quoteMatch[1] : '',
       nextTriggerCount: convertStringToNumber(LLMResponse.nextReplyIn),
-      logic: LLMResponse.logic || '',
+      logic: finalLogic || '',
       execute: LLMResponse.execute || [],
       usage: usage,
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ export interface Config {
     FirstTriggerCount: number;
     MaxTriggerCount: number;
     MinTriggerCount: number;
+    MaxTriggerTime: number;
+    MinTriggerTime: number;
     AtReactPossibility?: number;
     Filter: string[];
   };
@@ -128,6 +130,15 @@ export const Config: Schema<Config> = Schema.object({
       .default(1)
       .min(1)
       .description("Bot 两次回复之间的最小消息数"),
+    MaxTriggerTime: Schema.number()
+      .default(0)
+      .min(0)
+      .max(2147483)
+      .description("Bot 能容忍冷场的最长时间（秒），距离会话最后一条消息达到此时间时，将主动触发一次Bot回复，设为 0 表示 285427 年"),
+    MinTriggerTime: Schema.number()
+      .default(1000)
+      .min(0)
+      .description("Bot 单次触发冷却（毫秒），冷却期间如又触发回复，将处理新触发回复，跳过本次触发"),
     AtReactPossibility: Schema.number()
       .default(0.5)
       .min(0)


### PR DESCRIPTION
- 修复当不启用 `AllowErrorFormat` 时，跳过的消息被当成错误的消息的问题
- 消息重定向中的逻辑中的引用回复现在也会被转义成 `[引用回复: 消息ID]` 了
- 新增配置项 `MaxTriggerTime`，表示机器人在同一会话中，距离最后一条消息达到这么多秒后，将主动触发一次回复。最多设为 `2147483` 秒（24天20小时29分钟43秒）。设为 0 表示关闭此功能
- 新增配置项 `MinTriggerTime`，表示机器人在同一会话中，收到一次可触发回复的消息时，等等看后面有没有更多的可触发回复的消息的等待时间，单位为毫秒。如果在这段等待时间内再次收到了可触发回复的消息，就放弃本条触发回复的处理，转而处理新的触发回复，因为它包含了最新的上下文。此项也可以用于设定API调用的最大频率