### PR TITLE
[fix & feat] 不在没必要的会话开计时器，修复all逻辑，清除记忆指令新增功能

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,7 @@ ${handledRes.originalRes}`);
 ---
 指令：${handledRes.execute?.length ? handledRes.execute : "无"}
 ---
-距离下次：${nextTriggerCount}
+距离下次：${nextTriggerCountbyLLM} -> ${nextTriggerCount}
 ---
 消耗: 输入 ${handledRes?.usage?.prompt_tokens}, 输出 ${handledRes?.usage?.completion_tokens}`;
         // 有时候 LLM 就算跳过回复，也会生成内容，这个时候应该无视跳过，发送内容

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export function apply(ctx: Context, config: Config) {
     }
 
     // 启动静默检查
-    if (config.MemorySlot.MaxTriggerTime > 0) {
+    if (config.MemorySlot.MaxTriggerTime > 0 && mergeQueueFrom.has(groupId)) {
       sendQueue.startQuietCheck(groupId, async () => {
         // 当静默期到达时获取回复
         ctx.logger.info("静默期到达，获取回复");

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export function apply(ctx: Context, config: Config) {
     const groupId: string = session.guildId || session.channelId;
     await ensureGroupMemberList(session, groupId);
     const [, matchedConfig] = isGroupAllowed(groupId, config.MemorySlot.SlotContains, config.Settings.FirsttoAll);
-    const mergeQueueFrom = sendQueue.getShouldIncludeQueue(matchedConfig, groupId);
+    const mergeQueueFrom = sendQueue.getShouldIncludeQueue(matchedConfig, groupId).included;
 
     if ((session.userId === session.selfId || mergeQueueFrom.has(groupId)) && config.Settings.AddWhattoQueue === "所有消息") {
       const senderName = session.userId === session.selfId ? await getBotName(config, session) : await getMemberName(config, session, session.userId);
@@ -111,18 +111,23 @@ export function apply(ctx: Context, config: Config) {
   });
 
   ctx.command('清除记忆', '清除 BOT 对会话的记忆')
-    .option('target', '-t <target> 指定要清除记忆的会话。使用 private:指定私聊会话', { authority: 3 })
+    .option('target', '-t <target> 指定要清除记忆的会话。使用 private:指定私聊会话，使用 all 或 private:all 分别清除所有群聊或私聊记忆', { authority: 3 })
     .usage('注意：如果使用 清除记忆 <target> 来清除记忆而不带-t参数，将会清除当前会话的记忆！')
-    .example('清除记忆')
-    .example('清除记忆 -t private:1234567890')
-    .example('清除记忆 -t 987654321')
+    .example([
+      '清除记忆',
+      '清除记忆 -t private:1234567890',
+      '清除记忆 -t 987654321',
+      '清除记忆 -t all',
+      '清除记忆 -t private:all'
+    ].join('\n'))
     .action(async ({ session, options }) => {
       const msgDestination = session.guildId || session.channelId;
       const clearGroupId = options.target || msgDestination;
-      const userContent = await processUserContent(config, session);
 
+      // 保存其他人发送的消息
       if (config.Settings.AddWhattoQueue === "所有此插件发送和接收的消息") {
         await ensureGroupMemberList(session, msgDestination);
+        const userContent = await processUserContent(config, session);
         sendQueue.updateSendQueue(
           msgDestination,
           await getMemberName(config, session, session.event.user.id),
@@ -133,12 +138,47 @@ export function apply(ctx: Context, config: Config) {
           config.MemorySlot.FirstTriggerCount,
           session.event.selfId
         );
-        sendQueue.clearQuietTimeout(msgDestination); // 收
+        sendQueue.clearQuietTimeout(msgDestination);
       }
 
-      const msg = sendQueue.clearSendQueue(clearGroupId)
-        ? `已清除关于 ${clearGroupId} 的记忆`
-        : `未找到关于 ${clearGroupId} 的记忆`;
+      // 要清除的会话集合
+      const targetGroups = clearGroupId.split(",")
+        .map(g => g.trim())
+        .filter(Boolean);
+      const { included } = sendQueue.getShouldIncludeQueue(new Set(targetGroups), msgDestination);
+
+      // 清除记忆
+      const clearResults = Array.from(included)
+        .map(id => ({ id, cleared: sendQueue.clearSendQueue(id) }))
+        .filter(r => r.cleared);
+
+      const messages = [];
+      if (clearResults.length > 0) {
+        const clearedIds = clearResults.map(r => r.id);
+        messages.push(`已清除关于 ${clearedIds.slice(0, 3).join(', ')}${clearedIds.length > 3 ? ' 等会话' : ''} 的记忆`);
+        // 从 targetGroups 中移除已清除的会话
+        clearResults.forEach(r => {
+          const index = targetGroups.indexOf(r.id);
+          if (index > -1) {
+            targetGroups.splice(index, 1);
+          }
+        });
+      }
+
+      // 移除 "private:all" 和 "all"
+      const specialGroups = ["private:all", "all"];
+      specialGroups.forEach(group => {
+        const index = targetGroups.indexOf(group);
+        if (index > -1) {
+          targetGroups.splice(index, 1);
+        }
+      });
+
+      if (targetGroups.length > 0) {
+        messages.push(`未找到关于 ${targetGroups.join(', ')} 的记忆`);
+      }
+
+      const msg = messages.join('，');
 
       const commandResponseId = config.Debug.TestMode
         ? (await session.bot.sendMessage(msgDestination, msg, null, { session }))[0]
@@ -172,7 +212,7 @@ export function apply(ctx: Context, config: Config) {
 
     const [isGuildAllowed, matchedConfig] = isGroupAllowed(groupId, config.MemorySlot.SlotContains, config.Settings.FirsttoAll);
     if (!isGuildAllowed) return next();
-    const mergeQueueFrom = sendQueue.getShouldIncludeQueue(matchedConfig, groupId);
+    const mergeQueueFrom = sendQueue.getShouldIncludeQueue(matchedConfig, groupId).included;
 
     // 更新消息队列，把这条消息加入队列
     if (config.Settings.AddWhattoQueue === "所有此插件发送和接收的消息" || config.Settings.AddWhattoQueue === "所有和LLM交互的消息") {

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -50,7 +50,7 @@ export class SendQueue {
     // 0 表示不静默，设为一个极大值
     this.quietPeriod = config.MemorySlot.MaxTriggerTime === 0
       ? MAX_TIMEOUT
-      : (config.MemorySlot.MaxTriggerTime*1000 || MAX_TIMEOUT);
+      : (config.MemorySlot.MaxTriggerTime * 1000 || MAX_TIMEOUT);
     this.loadFromFile();
   }
 
@@ -182,16 +182,31 @@ export class SendQueue {
     return false;
   }
 
+  // 获取应该包含的队列
+  getShouldIncludeQueue(groups: Set<string>, groupId?: string): Set<string> {
+    const hasPrivateAll = groups.has('private:all');
+    const hasAll = groups.has('all');
+
+    const shouldIncludeQueue = (key: string): boolean => {
+      if (hasPrivateAll && hasAll) return true;
+      if (hasPrivateAll) return key.startsWith('private:') || groups.has(key);
+      if (hasAll) return !key.startsWith('private:') || groups.has(key);
+      return groups.has(key);
+    };
+
+    const keysToCheck = groupId
+      ? [...this.sendQueueMap.keys(), groupId]
+      : [...this.sendQueueMap.keys()];
+
+    return new Set(keysToCheck.filter(shouldIncludeQueue));
+  }
+
   // 检查记忆槽位长度
   checkMixedQueueSize(groups: Set<string>, size: number): boolean {
-    let totalLength = 0;
+    const includeGroups = this.getShouldIncludeQueue(groups);
 
-    for (const group of groups) {
-      if (this.sendQueueMap.has(group)) {
-        const queue = this.sendQueueMap.get(group);
-        totalLength += queue.length;
-      }
-    }
+    const totalLength = Array.from(includeGroups)
+      .reduce((sum, key) => sum + this.sendQueueMap.get(key).length, 0);
 
     console.log(`记忆槽位的容量: ${totalLength} / ${size}`);
     return totalLength >= size;

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -296,6 +296,8 @@ export class SendQueue {
     for (const group of this.sendQueueMap.keys()) {
       if (group.startsWith(privatePrefix)) {
         this.sendQueueMap.delete(group);
+        this.triggerCountMap.delete(group);
+        this.lastTriggerTimeMap.delete(group);
         hasCleared = true;
       }
     }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -208,7 +208,7 @@ export function isGroupAllowed(groupId: string, allowedGroups: string[], debug: 
       // 检查全局允许
       if (!isPrivate && group === "all") {
         if (debug) {
-          matchedGroups.add(groupConfig);
+          groups.forEach(g => matchedGroups.add(g));
         } else {
           return [true, groups];
         }
@@ -216,7 +216,7 @@ export function isGroupAllowed(groupId: string, allowedGroups: string[], debug: 
       // 检查全局私聊允许
       if (isPrivate && group === "private:all") {
         if (debug) {
-          matchedGroups.add(groupConfig);
+          groups.forEach(g => matchedGroups.add(g));
         } else {
           return [true, groups];
         }
@@ -224,7 +224,7 @@ export function isGroupAllowed(groupId: string, allowedGroups: string[], debug: 
       // 精确匹配
       if (groupId === group) {
         if (debug) {
-          matchedGroups.add(groupConfig);
+          groups.forEach(g => matchedGroups.add(g));
         } else {
           return [true, groups];
         }


### PR DESCRIPTION
- 计时器只在isGroupAllowed为真时开启
- 补齐all和private:all的逻辑，清除记忆指令现在也支持这两个特殊的参数值
- 清除记忆指令新增可选参数-p <person>，用来让BOT完全忘记某人。这应用于保存的所有会话。person参数直接填账号，不需要带private:前缀