### PR TITLE
修复llm出错总是返回空请求

### DIFF
--- a/packages/core/src/agent/context-builder.ts
+++ b/packages/core/src/agent/context-builder.ts
@@ -1,5 +1,5 @@
 import { Services } from "@/shared/constants";
-import { ImagePart, TextPart } from "@xsai/shared-chat";
+import type { ImagePart, TextPart } from "@/dependencies/xsai";
 import { Context, Logger } from "koishi";
 
 import { AssetService } from "@/services/assets";

--- a/packages/core/src/agent/heartbeat-processor.ts
+++ b/packages/core/src/agent/heartbeat-processor.ts
@@ -1,5 +1,4 @@
-import { GenerateTextResult } from "@xsai/generate-text";
-import { Message } from "@xsai/shared-chat";
+import type { GenerateTextResult, Message } from "@/dependencies/xsai";
 import { Context, h, Logger, Session } from "koishi";
 import { v4 as uuidv4 } from "uuid";
 

--- a/packages/core/src/dependencies/xsai.ts
+++ b/packages/core/src/dependencies/xsai.ts
@@ -1,8 +1,34 @@
+// 统一的 XSAI 适配导出层
+// 说明：部分编辑器/打包器对 `export * from` 的值导出推断不稳定，
+// 这里显式导出 Chat/Stream 相关的主入口，避免 “has no exported member” 报错。
+
+// 提供商适配（可选使用）
 export * from "@xsai-ext/providers-cloud";
 export * from "@xsai-ext/providers-local";
+export type { ChatProvider } from "@xsai-ext/shared-providers";
 export * from "@xsai-ext/shared-providers";
+
+// 基础能力
+export type { EmbedManyOptions, EmbedManyResult, EmbedOptions, EmbedResult } from "@xsai/embed";
 export * from "@xsai/embed";
-export * from "@xsai/generate-text";
+
+// 文本生成（非流式）
+export { generateText } from "@xsai/generate-text";
+export type { GenerateTextResult } from "@xsai/generate-text";
+
+// Chat 相关类型
+export type {
+  ChatOptions,
+  CompletionStep,
+  CompletionToolCall,
+  CompletionToolResult,
+  Message,
+} from "@xsai/shared-chat";
 export * from "@xsai/shared-chat";
+
+// 文本生成（流式）
+export { streamText } from "@xsai/stream-text";
 export * from "@xsai/stream-text";
+
+// 其他工具
 export * from "@xsai/utils-chat";

--- a/packages/core/src/services/model/chat-model.ts
+++ b/packages/core/src/services/model/chat-model.ts
@@ -1,6 +1,13 @@
-import type { ChatProvider } from "@xsai-ext/shared-providers";
-import type { GenerateTextResult } from "@xsai/generate-text";
-import type { ChatOptions, CompletionStep, CompletionToolCall, CompletionToolResult, Message } from "@xsai/shared-chat";
+// 统一从适配层导入 xsai 相关类型与函数，避免直接依赖外部包导致的类型解析问题
+import type {
+    ChatProvider,
+    GenerateTextResult,
+    ChatOptions,
+    CompletionStep,
+    CompletionToolCall,
+    CompletionToolResult,
+    Message,
+} from "@/dependencies/xsai";
 import { Context } from "koishi";
 
 import { generateText, streamText } from "@/dependencies/xsai";
@@ -164,9 +171,34 @@ export class ChatModel extends BaseModel implements IChatModel {
         const result = await generateText(chatOptions);
         const duration = Date.now() - stime;
 
+        const finalText = result.text || "";
+        const hasNonTextOutputs =
+            (result.toolCalls && result.toolCalls.length > 0) ||
+            (result.toolResults && result.toolResults.length > 0) ||
+            // 某些提供方会在非流式下也返回 steps
+            ((result as any).steps && (result as any).steps.length > 0);
+
+        if (isEmpty(finalText) && !hasNonTextOutputs) {
+            const reason = (result.finishReason || "unknown").toString();
+            const abnormal = ["error", "content_filter", "filter", "length", "canceled", "cancelled"].includes(reason);
+            if (abnormal) {
+                const details = `上游以 ${reason} 结束，未产生任何可用文本`;
+                this.logger.warn(`💬 [非流式] 请求未产生文本，判定为请求失败 | 详情: ${details}`);
+                throw new AppError(ErrorDefinitions.LLM.REQUEST_FAILED, {
+                    args: [details],
+                    context: { rawResponse: finalText, finishReason: reason },
+                });
+            }
+
+            this.logger.warn(`💬 [非流式] 模型未输出有效内容（finishReason=${reason}）`);
+            throw new AppError(ErrorDefinitions.LLM.OUTPUT_EMPTY_CONTENT, {
+                context: { rawResponse: finalText, details: "模型未输出有效内容", finishReason: reason },
+            });
+        }
+
         const logMessage = result.toolCalls?.length
-            ? `工具调用: "${result.toolCalls.map((tc) => tc.toolName).join(", ")}"`
-            : `文本长度: ${result.text.length}`;
+            ? `工具调用: "${result.toolCalls.map((tc: CompletionToolCall) => tc.toolName).join(", ")}"`
+            : `文本长度: ${finalText.length}`;
         this.logger.success(`✅ [请求成功] [非流式] ${logMessage} | 耗时: ${duration}ms`);
         return result;
     }
@@ -251,11 +283,37 @@ export class ChatModel extends BaseModel implements IChatModel {
 
         const duration = Date.now() - stime;
         const finalText = finalContentParts.join("");
+        const hasNonTextOutputs =
+            (finalToolCalls && finalToolCalls.length > 0) ||
+            (finalToolResults && finalToolResults.length > 0) ||
+            (finalSteps && finalSteps.length > 0);
 
-        if (isEmpty(finalText)) {
-            this.logger.warn(`💬 [流式] 模型未输出有效内容`);
+        // 细化“空输出”场景：
+        // - 如果流根本未开始，或 finishReason 暗示了错误/被过滤，则按“请求失败”处理，保留更具体的错误语义
+        // - 仅在确认流已开始且没有其他错误线索时，才判定为 OUTPUT_EMPTY_CONTENT
+        if (isEmpty(finalText) && !hasNonTextOutputs) {
+            const reason = (finalFinishReason || "unknown").toString();
+            const streamInfo = { streamStarted, finishReason: reason };
+
+            // 常见的“非正常结束”理由：error / content_filter / length（被截断但没有内容）/ canceled / cancelled
+            const abnormal =
+                !streamStarted || ["error", "content_filter", "filter", "length", "canceled", "cancelled"].includes(reason);
+
+            if (abnormal) {
+                const details = !streamStarted
+                    ? "未收到任何流数据，可能是网络中断、超时或上游服务错误"
+                    : `上游以 ${reason} 结束，未产生任何可用文本`;
+                this.logger.warn(`💬 [流式] 请求未产生文本，判定为请求失败 | 详情: ${details}`);
+                throw new AppError(ErrorDefinitions.LLM.REQUEST_FAILED, {
+                    args: [details],
+                    context: { rawResponse: finalText, ...streamInfo },
+                });
+            }
+
+            // 正常开始且无异常 finishReason，但最终文本为空，保留原有含义：模型确实返回了空内容
+            this.logger.warn(`💬 [流式] 模型未输出有效内容（流已开始，finishReason=${reason}）`);
             throw new AppError(ErrorDefinitions.LLM.OUTPUT_EMPTY_CONTENT, {
-                context: { rawResponse: finalText, details: "模型未输出有效内容" },
+                context: { rawResponse: finalText, details: "模型未输出有效内容", ...streamInfo },
             });
         }
 
@@ -263,7 +321,8 @@ export class ChatModel extends BaseModel implements IChatModel {
         this.logger.debug(`🏁 [流式] 传输完成 | 总耗时: ${duration}ms | 输入: ${finalUsage?.prompt_tokens || "N/A"} | 输出: ${finalUsage?.completion_tokens || `~${finalText.length / 4}`}`);
 
         // 对最终拼接的完整内容进行最后一次验证
-        if (validator) {
+        // 注意：若无任何文本输出但存在工具调用/步骤等非文本产出，则跳过文本验证
+        if (validator && !(isEmpty(finalText) && hasNonTextOutputs)) {
             const finalValidation = validator(finalText, true);
             if (!finalValidation.valid) {
                 const errorMsg = finalValidation.error || "格式不匹配或模型未输出有效内容";

--- a/packages/core/src/services/model/embed-model.ts
+++ b/packages/core/src/services/model/embed-model.ts
@@ -1,6 +1,5 @@
-import type { EmbedProvider } from "@xsai-ext/shared-providers";
-import type { EmbedManyOptions, EmbedManyResult, EmbedOptions, EmbedResult } from "@xsai/embed";
-import { Context } from "koishi";
+import type { EmbedProvider, EmbedManyOptions, EmbedManyResult, EmbedOptions, EmbedResult } from "@/dependencies/xsai";
+import type { Context } from "koishi";
 
 import { embed, embedMany } from "@/dependencies/xsai";
 import { BaseModel } from "./base-model";

--- a/packages/core/src/services/model/factories.ts
+++ b/packages/core/src/services/model/factories.ts
@@ -5,7 +5,7 @@ import type {
     ModelProvider,
     SpeechProvider,
     TranscriptionProvider,
-} from "@xsai-ext/shared-providers";
+} from "@/dependencies/xsai";
 
 import {
     createAnthropic,

--- a/packages/core/src/services/model/service.ts
+++ b/packages/core/src/services/model/service.ts
@@ -4,7 +4,7 @@ import { Config } from "@/config";
 import { Services } from "@/shared/constants";
 import { AppError, ErrorDefinitions } from "@/shared/errors";
 import { isNotEmpty } from "@/shared/utils";
-import { GenerateTextResult } from "@xsai/generate-text";
+import type { GenerateTextResult } from "@/dependencies/xsai";
 import { BaseModel } from "./base-model";
 import { ChatRequestOptions, IChatModel } from "./chat-model";
 import { CircuitBreakerPolicy, ContentFailureAction, ModelDescriptor, ModelSwitchingStrategy } from "./config";
@@ -333,12 +333,21 @@ class RequestExecutor {
             const attemptLogger = this.logger.extend(`[${model.id}] [尝试 ${attempt + 1}/${retryPolicy.maxRetries + 1}]`);
             const controller = new AbortController();
 
-            const firstTokenTimeoutId = setTimeout(() => {
-                const timeoutError = new Error(`First token not received within ${timeoutPolicy.firstTokenTimeout}s`);
-                timeoutError.name = "AbortError";
-                timeoutError["duration"] = timeoutPolicy.firstTokenTimeout;
-                controller.abort(timeoutError);
-            }, timeoutPolicy.firstTokenTimeout * 1000);
+            // 仅当配置了 firstTokenTimeout 时才启用“首个 Token”超时
+            const firstTokenTimeoutMs =
+                typeof (timeoutPolicy as any).firstTokenTimeout === "number" && (timeoutPolicy as any).firstTokenTimeout > 0
+                    ? (timeoutPolicy as any).firstTokenTimeout * 1000
+                    : null;
+
+            const firstTokenTimeoutId = firstTokenTimeoutMs
+                ? setTimeout(() => {
+                      const secs = (timeoutPolicy as any).firstTokenTimeout;
+                      const timeoutError = new Error(`First token not received within ${secs}s`);
+                      timeoutError.name = "AbortError";
+                      (timeoutError as any)["duration"] = secs;
+                      controller.abort(timeoutError);
+                  }, firstTokenTimeoutMs)
+                : undefined as any;
 
             const timeoutId = setTimeout(() => {
                 const timeoutError = new Error(`Request timed out after ${timeoutPolicy.totalTimeout}s`);
@@ -352,7 +361,7 @@ class RequestExecutor {
             options_copy.abortSignal = controller.signal;
 
             options_copy.onStreamStart = () => {
-                clearTimeout(firstTokenTimeoutId);
+                if (firstTokenTimeoutId) clearTimeout(firstTokenTimeoutId);
             };
 
             try {


### PR DESCRIPTION
**统一从适配层导入 xsai 模块**  
- 规范化类型与方法的引入方式，避免直接依赖外部包导致的类型解析或推断问题。  
- 在 `generateText` 和 `streamText` 的非流式/流式生成逻辑中细化空输出和错误场景的处理逻辑，优化日志与异常信息。  
- 增强超时处理逻辑，确保仅在配置了 `firstTokenTimeout` 时生效。

建议检查一下，应该没问题（

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了请求超时处理逻辑，避免在未配置超时时的误触发
  * 优化了空内容检测和错误处理，增强了混合输出场景的验证准确性

* **重构**
  * 统一模块导入结构，提升代码组织效率

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->