### PR TITLE
Fix baseURL handling and improve model endpoint resolution logic

### DIFF
--- a/packages/shared-model/package.json
+++ b/packages/shared-model/package.json
@@ -18,8 +18,8 @@
     "./package.json": "./package.json"
   },
   "devDependencies": {
-    "xsai": "^0.4.0-beta.10",
-    "@xsai-ext/providers": "^0.4.0-beta.10"
+    "@xsai-ext/providers": "^0.4.0-beta.10",
+    "xsai": "^0.4.0-beta.10"
   },
   "dependencies": {
     "undici": "^7.16.0"

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -173,8 +173,8 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
             throw new Error("无法获取在线模型列表：缺少 baseURL 配置");
         }
 
-        // 智能拼接：如果 baseURL 不以 /v1 结尾，则自动补上
-        const url = baseURL.endsWith("/v1") ? `${baseURL}/models` : `${baseURL}/v1/models`;
+        // 拼接模型列表路径：baseURL 此时应该已经包含了版本号（如 /v1 或 /v4）
+        const url = `${baseURL}/models`;
 
         const response = await this.fetch(url, {
             method: "GET",

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -176,7 +176,7 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
         = undefined as any;
 
     public async getOnlineModels(): Promise<string[]> {
-        const baseURL = normalizeBaseURL(this.config.baseURL);
+        const baseURL = normalizeBaseURL(this.config.baseURL, this.logger);
         if (!baseURL) {
             throw new Error("无法获取在线模型列表：缺少 baseURL 配置");
         }

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -173,13 +173,14 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
             throw new Error("无法获取在线模型列表：缺少 baseURL 配置");
         }
 
-        // 智能补全 /v1：如果 baseURL 不以 /v{数字} 结尾，且不是以 models 结尾，则尝试补全
-        // 这样可以保持基类的独立性，不依赖于子类的预处理
+        // 智能补全 /v1/models：
+        // 1. 如果包含版本号(如 /v1)，则确保指向 /v1/models
+        // 2. 如果不包含版本号且不以 /models 结尾，则补全 /v1/models
         let url = baseURL;
-        if (!/\/v\d+$/.test(baseURL) && !baseURL.endsWith("/models")) {
-            url += "/v1/models";
+        if (/\/v\d+(?:\/|$)/.test(baseURL)) {
+            url = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1/models");
         } else if (!baseURL.endsWith("/models")) {
-            url += "/models";
+            url = baseURL + "/v1/models";
         }
 
         const response = await this.fetch(url, {

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -9,7 +9,7 @@ import type {
 import type { CommonRequestOptions } from "xsai";
 import type { AnyFetch } from "./utils";
 import { fetch as ufetch } from "undici";
-import { createSharedFetch } from "./utils";
+import { createSharedFetch, normalizeBaseURL } from "./utils";
 
 export * from "./utils";
 export * from "@xsai-ext/providers";
@@ -168,20 +168,12 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
         = undefined as any;
 
     public async getOnlineModels(): Promise<string[]> {
-        let baseURL = this.config.baseURL.trim().replace(/\/+$/, "");
+        const baseURL = normalizeBaseURL(this.config.baseURL);
         if (!baseURL) {
             throw new Error("无法获取在线模型列表：缺少 baseURL 配置");
         }
 
-        // 智能补全 /v1/models：
-        // 1. 如果包含版本号(如 /v1)，则确保指向 /v1/models
-        // 2. 如果不包含版本号且不以 /models 结尾，则补全 /v1/models
-        let url = baseURL;
-        if (/\/v\d+(?:\/|$)/.test(baseURL)) {
-            url = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1/models");
-        } else if (!baseURL.endsWith("/models")) {
-            url = baseURL + "/v1/models";
-        }
+        const url = `${baseURL}/models`;
 
         const response = await this.fetch(url, {
             method: "GET",

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -173,15 +173,21 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
             throw new Error("无法获取在线模型列表：缺少 baseURL 配置");
         }
 
-        // 拼接模型列表路径：baseURL 此时应该已经包含了版本号（如 /v1 或 /v4）
-        const url = `${baseURL}/models`;
+        // 智能补全 /v1：如果 baseURL 不以 /v{数字} 结尾，且不是以 models 结尾，则尝试补全
+        // 这样可以保持基类的独立性，不依赖于子类的预处理
+        let url = baseURL;
+        if (!/\/v\d+$/.test(baseURL) && !baseURL.endsWith("/models")) {
+            url += "/v1/models";
+        } else if (!baseURL.endsWith("/models")) {
+            url += "/models";
+        }
 
         const response = await this.fetch(url, {
             method: "GET",
             headers: { Authorization: `Bearer ${this.config.apiKey}` },
         });
         if (!response.ok) {
-            throw new Error(`获取在线模型列表失败，状态码：${response.status}`);
+            throw new Error(`获取在线模型列表失败，状态码：${response.status}，URL：${url}`);
         }
         const data = await response.json();
         return data.data.map((item: any) => item.id) as string[];

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -168,12 +168,15 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
         = undefined as any;
 
     public async getOnlineModels(): Promise<string[]> {
-        const baseURL = this.config.baseURL;
+        let baseURL = this.config.baseURL.trim().replace(/\/+$/, "");
         if (!baseURL) {
             throw new Error("无法获取在线模型列表：缺少 baseURL 配置");
         }
 
-        const response = await this.fetch(`${baseURL}/v1/models`, {
+        // 智能拼接：如果 baseURL 不以 /v1 结尾，则自动补上
+        const url = baseURL.endsWith("/v1") ? `${baseURL}/models` : `${baseURL}/v1/models`;
+
+        const response = await this.fetch(url, {
             method: "GET",
             headers: { Authorization: `Bearer ${this.config.apiKey}` },
         });

--- a/packages/shared-model/src/index.ts
+++ b/packages/shared-model/src/index.ts
@@ -88,6 +88,12 @@ type UnionProvider
         | SpeechProvider<any>
         | TranscriptionProvider<any>;
 
+export interface ProviderRuntime {
+    fetch?: AnyFetch;
+    proxy?: string;
+    logger?: any;
+}
+
 export abstract class SharedProvider<TProvider extends UnionProvider = any, TModelConfig = {}> {
     public readonly name: string;
 
@@ -95,15 +101,17 @@ export abstract class SharedProvider<TProvider extends UnionProvider = any, TMod
     protected fetch: AnyFetch
         = typeof globalThis.fetch === "function" ? globalThis.fetch : (ufetch as unknown as AnyFetch);
 
+    protected readonly logger: any;
     private readonly shouldInjectFetch: boolean;
 
     constructor(
         name: string,
         protected readonly provider: TProvider,
         protected readonly config: SharedConfig<TModelConfig>,
-        runtime?: { fetch?: AnyFetch; proxy?: string },
+        runtime?: ProviderRuntime,
     ) {
         this.name = name;
+        this.logger = runtime?.logger;
 
         this.fetch = createSharedFetch({
             fetch: runtime?.fetch,

--- a/packages/shared-model/src/utils.ts
+++ b/packages/shared-model/src/utils.ts
@@ -123,3 +123,36 @@ export function deepMerge<T>(base: T, ...overrides: Array<Partial<T> | undefined
 
     return result as T;
 }
+
+/**
+ * 归一化 baseURL
+ * 1. 去除首尾空格
+ * 2. 移除末尾多余斜杠
+ * 3. 智能补全/截断版本号：
+ *    - 如果包含版本号(如 /v1, /v4)，则保留到版本号为止
+ *    - 如果不包含版本号，会自动补全 /v1
+ *    - 如果包含 /models 但无版本号，会将其替换为 /v1
+ */
+export function normalizeBaseURL(url: string | undefined | null): string {
+    let baseURL = (url || "").trim();
+    if (!baseURL || baseURL.replace(/\/+$/, "") === "") {
+        return "";
+    }
+
+    // 移除末尾斜杠
+    baseURL = baseURL.replace(/\/+$/, "");
+
+    // 如果包含版本号(如 /v1, /v4)，则截断到版本号为止
+    if (/\/v\d+(?:\/|$)/.test(baseURL)) {
+        baseURL = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1");
+    } else {
+        // 如果以 /models 结尾但没有版本号，先移除 /models
+        if (baseURL.endsWith("/models")) {
+            baseURL = baseURL.slice(0, -7).replace(/\/+$/, "");
+        }
+        // 补上 /v1
+        baseURL += "/v1";
+    }
+
+    return baseURL;
+}

--- a/packages/shared-model/src/utils.ts
+++ b/packages/shared-model/src/utils.ts
@@ -130,8 +130,8 @@ export function deepMerge<T>(base: T, ...overrides: Array<Partial<T> | undefined
  * 2. 移除末尾多余斜杠
  * 3. 智能补全/截断版本号：
  *    - 如果包含版本号(如 /v1, /v4)，则保留到版本号为止
- *    - 如果不包含版本号，会自动补全 /v1
- *    - 如果包含 /models 但无版本号，会将其替换为 /v1
+ *    - 如果不包含版本号且无路径，会自动补全 /v1
+ *    - 如果不包含版本号但有路径，则截断到域名根部
  */
 export function normalizeBaseURL(url: string | undefined | null, logger?: { warn: (msg: string) => void }): string {
     let baseURL = (url || "").trim();
@@ -156,15 +156,17 @@ export function normalizeBaseURL(url: string | undefined | null, logger?: { warn
     if (versionMatches) {
         baseURL = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1");
     } else {
-        // 如果没有版本号，但包含路径（如 /chat/completions），则截断到域名根部
-        // 我们通过寻找第一个斜杠（排除协议后的斜杠）之后的内容来尝试识别
-        const urlObj = new URL(baseURL.includes("://") ? baseURL : `http://${baseURL}`);
+        // 如果没有版本号，则根据是否有路径决定补全还是截断
+        const hasProtocol = baseURL.includes("://");
+        const urlObj = new URL(hasProtocol ? baseURL : `http://${baseURL}`);
         if (urlObj.pathname !== "/" && urlObj.pathname !== "") {
-            // 如果路径不为空，我们只保留协议和域名
-            baseURL = `${urlObj.protocol}//${urlObj.host}`;
+            // 如果有路径（如 /chat/completions），截断到域名根部
+            baseURL = hasProtocol ? urlObj.origin : urlObj.host;
+        } else {
+            // 如果无路径，补上 /v1
+            baseURL = hasProtocol ? urlObj.origin : urlObj.host;
+            baseURL += "/v1";
         }
-        // 补上 /v1
-        baseURL += "/v1";
     }
 
     return baseURL;

--- a/packages/shared-model/src/utils.ts
+++ b/packages/shared-model/src/utils.ts
@@ -133,7 +133,7 @@ export function deepMerge<T>(base: T, ...overrides: Array<Partial<T> | undefined
  *    - 如果不包含版本号，会自动补全 /v1
  *    - 如果包含 /models 但无版本号，会将其替换为 /v1
  */
-export function normalizeBaseURL(url: string | undefined | null): string {
+export function normalizeBaseURL(url: string | undefined | null, logger?: { warn: (msg: string) => void }): string {
     let baseURL = (url || "").trim();
     if (!baseURL || baseURL.replace(/\/+$/, "") === "") {
         return "";
@@ -142,8 +142,18 @@ export function normalizeBaseURL(url: string | undefined | null): string {
     // 移除末尾斜杠
     baseURL = baseURL.replace(/\/+$/, "");
 
+    // 检查版本号数量
+    const versionMatches = baseURL.match(/\/v\d+(?=\/|$)/g);
+    if (versionMatches && versionMatches.length > 1) {
+        const msg = `检测到 baseURL 中包含多个版本号: ${baseURL}，将跳过自动截断/补全逻辑。`;
+        if (logger)
+            logger.warn(msg);
+        else console.warn(`[yesimbot] ${msg}`);
+        return baseURL;
+    }
+
     // 如果包含版本号(如 /v1, /v4)，则截断到版本号为止
-    if (/\/v\d+(?:\/|$)/.test(baseURL)) {
+    if (versionMatches) {
         baseURL = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1");
     } else {
         // 如果以 /models 结尾但没有版本号，先移除 /models

--- a/packages/shared-model/src/utils.ts
+++ b/packages/shared-model/src/utils.ts
@@ -156,9 +156,12 @@ export function normalizeBaseURL(url: string | undefined | null, logger?: { warn
     if (versionMatches) {
         baseURL = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1");
     } else {
-        // 如果以 /models 结尾但没有版本号，先移除 /models
-        if (baseURL.endsWith("/models")) {
-            baseURL = baseURL.slice(0, -7).replace(/\/+$/, "");
+        // 如果没有版本号，但包含路径（如 /chat/completions），则截断到域名根部
+        // 我们通过寻找第一个斜杠（排除协议后的斜杠）之后的内容来尝试识别
+        const urlObj = new URL(baseURL.includes("://") ? baseURL : `http://${baseURL}`);
+        if (urlObj.pathname !== "/" && urlObj.pathname !== "") {
+            // 如果路径不为空，我们只保留协议和域名
+            baseURL = `${urlObj.protocol}//${urlObj.host}`;
         }
         // 补上 /v1
         baseURL += "/v1";

--- a/packages/shared-model/src/utils.ts
+++ b/packages/shared-model/src/utils.ts
@@ -158,14 +158,22 @@ export function normalizeBaseURL(url: string | undefined | null, logger?: { warn
     } else {
         // 如果没有版本号，则根据是否有路径决定补全还是截断
         const hasProtocol = baseURL.includes("://");
-        const urlObj = new URL(hasProtocol ? baseURL : `http://${baseURL}`);
-        if (urlObj.pathname !== "/" && urlObj.pathname !== "") {
-            // 如果有路径（如 /chat/completions），截断到域名根部
-            baseURL = hasProtocol ? urlObj.origin : urlObj.host;
-        } else {
-            // 如果无路径，补上 /v1
-            baseURL = hasProtocol ? urlObj.origin : urlObj.host;
-            baseURL += "/v1";
+        try {
+            const urlObj = new URL(hasProtocol ? baseURL : `http://${baseURL}`);
+            if (urlObj.pathname !== "/" && urlObj.pathname !== "") {
+                // 如果有路径（如 /chat/completions），截断到域名根部
+                baseURL = hasProtocol ? urlObj.origin : urlObj.host;
+            } else {
+                // 如果无路径，补上 /v1
+                baseURL = hasProtocol ? urlObj.origin : urlObj.host;
+                baseURL += "/v1";
+            }
+        } catch (err) {
+            const msg = `检测到无效的 baseURL: ${baseURL}，将跳过自动截断/补全逻辑。`;
+            if (logger)
+                logger.warn(msg);
+            else console.warn(`[yesimbot] ${msg}`);
+            return baseURL;
         }
     }
 

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -40,9 +40,9 @@ export const Config: Schema<Config> = Schema.object({
 });
 
 class OpenAIProvider extends SharedProvider<any, ModelConfig> {
-    constructor(name: string, provider: any, config: Config, runtime?: { fetch?: any; proxy?: string }) {
+    constructor(name: string, provider: any, config: Config, runtime?: { fetch?: any; proxy?: string; logger?: any }) {
         const processedConfig = { ...config };
-        const baseURL = normalizeBaseURL(processedConfig.baseURL);
+        const baseURL = normalizeBaseURL(processedConfig.baseURL, runtime?.logger);
 
         if (baseURL) {
             processedConfig.baseURL = baseURL;
@@ -54,7 +54,7 @@ class OpenAIProvider extends SharedProvider<any, ModelConfig> {
 
 export function apply(ctx: Context, config: Config) {
     const providerName = "openai";
-    const provider = new OpenAIProvider("openai", {} as any, config, { proxy: config.proxy });
+    const provider = new OpenAIProvider("openai", {} as any, config, { proxy: config.proxy, logger: ctx.logger });
     ctx.on("ready", async () => {
         const registry = ctx.get("yesimbot.model");
         if (!registry) {

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -44,19 +44,17 @@ class OpenAIProvider extends SharedProvider<any, ModelConfig> {
         const processedConfig = { ...config };
         let baseURL = (processedConfig.baseURL || "").trim();
 
-        if (!baseURL || baseURL.replace(/\/+$/, "") === "") {
-            throw new Error("无效的 baseURL：值为空或仅包含斜杠。");
+        // 如果 baseURL 有值且不只是斜杠，则进行处理
+        if (baseURL && baseURL.replace(/\/+$/, "") !== "") {
+            // 移除末尾斜杠
+            baseURL = baseURL.replace(/\/+$/, "");
+
+            // 如果不以版本号(如 /v1, /v4)结尾，则补上 /v1
+            if (!/\/v\d+$/.test(baseURL)) {
+                baseURL += "/v1";
+            }
+            processedConfig.baseURL = baseURL;
         }
-
-        // 移除末尾斜杠
-        baseURL = baseURL.replace(/\/+$/, "");
-
-        // 如果不以版本号(如 /v1, /v4)结尾，则补上 /v1
-        if (!/\/v\d+$/.test(baseURL)) {
-            baseURL += "/v1";
-        }
-
-        processedConfig.baseURL = baseURL;
 
         super(name, provider, processedConfig, runtime);
     }

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -52,11 +52,11 @@ class OpenAIProvider extends SharedProvider<any, ModelConfig> {
                 baseURL += "/v1";
             }
             if (!baseURL) {
-                throw new Error("Invalid baseURL: value is empty after normalization.");
+                throw new Error("无效的 baseURL：标准化处理后值为空。");
             }
             processedConfig.baseURL = baseURL;
         } else {
-            throw new Error("Invalid baseURL: value is empty.");
+            throw new Error("无效的 baseURL：值为空。");
         }
         super(name, provider, processedConfig, runtime);
     }

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -20,7 +20,7 @@ export const usage = "";
 export const inject = ["yesimbot.model"];
 
 export const Config: Schema<Config> = Schema.object({
-    baseURL: Schema.string().default("https://api.openai.com/"),
+    baseURL: Schema.string().default("https://api.openai.com/v1/"),
     apiKey: Schema.string().role("secret").required(),
     proxy: Schema.string().default(""),
     retryDefault: Schema.number().min(0).default(3),
@@ -39,7 +39,23 @@ export const Config: Schema<Config> = Schema.object({
     "en-US": require("./locales/en-US.yml")._config,
 });
 
-class OpenAIProvider extends SharedProvider<any, ModelConfig> {}
+class OpenAIProvider extends SharedProvider<any, ModelConfig> {
+    constructor(name: string, provider: any, config: Config, runtime?: { fetch?: any; proxy?: string }) {
+        const processedConfig = { ...config };
+        if (processedConfig.baseURL) {
+            let baseURL = processedConfig.baseURL.trim();
+            if (baseURL.endsWith("/")) {
+                baseURL = baseURL.slice(0, -1);
+            }
+            // 如果不以版本号(如 /v1, /v4)结尾，则补上 /v1
+            if (!/\/v\d+$/.test(baseURL)) {
+                baseURL += "/v1";
+            }
+            processedConfig.baseURL = baseURL;
+        }
+        super(name, provider, processedConfig, runtime);
+    }
+}
 
 export function apply(ctx: Context, config: Config) {
     const providerName = "openai";

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable ts/no-redeclare */
 import type { ChatModelConfig, SharedConfig } from "@yesimbot/shared-model";
 import type { Context } from "koishi";
-import { ChatModelAbility, ModelType, SharedProvider } from "@yesimbot/shared-model";
+import { ChatModelAbility, ModelType, SharedProvider, normalizeBaseURL } from "@yesimbot/shared-model";
 import { Schema } from "koishi";
 
 export interface ModelConfig extends ChatModelConfig {
@@ -42,19 +42,9 @@ export const Config: Schema<Config> = Schema.object({
 class OpenAIProvider extends SharedProvider<any, ModelConfig> {
     constructor(name: string, provider: any, config: Config, runtime?: { fetch?: any; proxy?: string }) {
         const processedConfig = { ...config };
-        let baseURL = (processedConfig.baseURL || "").trim();
+        const baseURL = normalizeBaseURL(processedConfig.baseURL);
 
-        // 如果 baseURL 有值且不只是斜杠，则进行处理
-        if (baseURL && baseURL.replace(/\/+$/, "") !== "") {
-            // 移除末尾斜杠
-            baseURL = baseURL.replace(/\/+$/, "");
-
-            // 如果包含版本号(如 /v1, /v4)，则保留到版本号为止；否则补上 /v1
-            if (/\/v\d+(?:\/|$)/.test(baseURL)) {
-                baseURL = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1");
-            } else {
-                baseURL += "/v1";
-            }
+        if (baseURL) {
             processedConfig.baseURL = baseURL;
         }
 

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -20,7 +20,7 @@ export const usage = "";
 export const inject = ["yesimbot.model"];
 
 export const Config: Schema<Config> = Schema.object({
-    baseURL: Schema.string().default("https://api.openai.com/v1/"),
+    baseURL: Schema.string().default("https://api.openai.com/"),
     apiKey: Schema.string().role("secret").required(),
     proxy: Schema.string().default(""),
     retryDefault: Schema.number().min(0).default(3),

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -49,8 +49,10 @@ class OpenAIProvider extends SharedProvider<any, ModelConfig> {
             // 移除末尾斜杠
             baseURL = baseURL.replace(/\/+$/, "");
 
-            // 如果不以版本号(如 /v1, /v4)结尾，则补上 /v1
-            if (!/\/v\d+$/.test(baseURL)) {
+            // 如果包含版本号(如 /v1, /v4)，则保留到版本号为止；否则补上 /v1
+            if (/\/v\d+(?:\/|$)/.test(baseURL)) {
+                baseURL = baseURL.replace(/(\/v\d+)(?:\/.*)?$/, "$1");
+            } else {
                 baseURL += "/v1";
             }
             processedConfig.baseURL = baseURL;

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable ts/no-require-imports */
 /* eslint-disable ts/no-redeclare */
-import type { ChatModelConfig, SharedConfig } from "@yesimbot/shared-model";
+import type { ChatModelConfig, ProviderRuntime, SharedConfig } from "@yesimbot/shared-model";
 import type { Context } from "koishi";
 import { ChatModelAbility, ModelType, SharedProvider, normalizeBaseURL } from "@yesimbot/shared-model";
 import { Schema } from "koishi";
@@ -40,7 +40,7 @@ export const Config: Schema<Config> = Schema.object({
 });
 
 class OpenAIProvider extends SharedProvider<any, ModelConfig> {
-    constructor(name: string, provider: any, config: Config, runtime?: { fetch?: any; proxy?: string; logger?: any }) {
+    constructor(name: string, provider: any, config: Config, runtime?: ProviderRuntime) {
         const processedConfig = { ...config };
         const baseURL = normalizeBaseURL(processedConfig.baseURL, runtime?.logger);
 

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -51,7 +51,12 @@ class OpenAIProvider extends SharedProvider<any, ModelConfig> {
             if (!/\/v\d+$/.test(baseURL)) {
                 baseURL += "/v1";
             }
+            if (!baseURL) {
+                throw new Error("Invalid baseURL: value is empty after normalization.");
+            }
             processedConfig.baseURL = baseURL;
+        } else {
+            throw new Error("Invalid baseURL: value is empty.");
         }
         super(name, provider, processedConfig, runtime);
     }

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -42,22 +42,22 @@ export const Config: Schema<Config> = Schema.object({
 class OpenAIProvider extends SharedProvider<any, ModelConfig> {
     constructor(name: string, provider: any, config: Config, runtime?: { fetch?: any; proxy?: string }) {
         const processedConfig = { ...config };
-        if (processedConfig.baseURL) {
-            let baseURL = processedConfig.baseURL.trim();
-            if (baseURL.endsWith("/")) {
-                baseURL = baseURL.slice(0, -1);
-            }
-            // 如果不以版本号(如 /v1, /v4)结尾，则补上 /v1
-            if (!/\/v\d+$/.test(baseURL)) {
-                baseURL += "/v1";
-            }
-            if (!baseURL) {
-                throw new Error("无效的 baseURL：标准化处理后值为空。");
-            }
-            processedConfig.baseURL = baseURL;
-        } else {
-            throw new Error("无效的 baseURL：值为空。");
+        let baseURL = (processedConfig.baseURL || "").trim();
+
+        if (!baseURL || baseURL.replace(/\/+$/, "") === "") {
+            throw new Error("无效的 baseURL：值为空或仅包含斜杠。");
         }
+
+        // 移除末尾斜杠
+        baseURL = baseURL.replace(/\/+$/, "");
+
+        // 如果不以版本号(如 /v1, /v4)结尾，则补上 /v1
+        if (!/\/v\d+$/.test(baseURL)) {
+            baseURL += "/v1";
+        }
+
+        processedConfig.baseURL = baseURL;
+
         super(name, provider, processedConfig, runtime);
     }
 }


### PR DESCRIPTION
没错我又来了
我发现新增加的模型获取与默认完全不符合
默认是xxx/v1，而请求的时候又加了v1，这导致变成了v1/v1
会自动拼接，无论有没有v1都能用，还能处理一些简单的空格