### PR TITLE
feat(will-policy): 支持按频道覆盖意愿值参数

### DIFF
--- a/openspec/changes/add-will-policy-channel-overrides/proposal.md
+++ b/openspec/changes/add-will-policy-channel-overrides/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+Willingness 目前只能为所有频道共用一组增益参数。不同群的消息频率和交互密度差异很大，全局参数容易让高活跃群过度触发，或让低活跃群难以触发。
+
+## What Changes
+
+- 在 willingness 配置中新增有序 `channelOverrides` 规则表。
+- 规则按 `platform`、`channelId` 和可选 `isDirect` 匹配频道。
+- 首期仅允许覆盖 `textGain` 和 `keywordMultiplier`，保持范围最小。
+- 按配置顺序采用第一条匹配规则；未匹配时保持全局值。
+- 私聊规则接受普通账号，匹配时规范化为 `private:<account>`。
+
+## Impact
+
+变更限于 `plugins/will-policy` 的配置 Schema、类型、频道引擎初始化、测试和文档。WillEngine 和 Core 接口不变；不配置规则时行为完全兼容。

--- a/openspec/changes/add-will-policy-channel-overrides/specs/will-policy-channel-overrides/spec.md
+++ b/openspec/changes/add-will-policy-channel-overrides/specs/will-policy-channel-overrides/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Channel-scoped willingness overrides
+
+The will-policy plugin SHALL allow willingness configurations to override `textGain` and `keywordMultiplier` for selected channels without changing the global defaults.
+
+#### Scenario: Matching channel uses overrides
+
+- **WHEN** a channel matches an override by platform, channel ID, and optional direct-message flag
+- **THEN** the channel-scoped willingness engine uses every value present in that override
+- **AND** omitted override fields continue to use their global values
+
+#### Scenario: Rules have deterministic priority
+
+- **WHEN** more than one override matches a channel
+- **THEN** only the first matching rule in configuration order is applied
+
+#### Scenario: Unmatched channel remains compatible
+
+- **WHEN** no override matches a channel or the rule table is empty
+- **THEN** the engine uses the existing global willingness configuration unchanged
+
+#### Scenario: Direct account IDs are normalized
+
+- **WHEN** an override can match direct messages and its channel ID lacks the `private:` prefix
+- **THEN** the plugin matches it against the equivalent `private:<channelId>` runtime channel
+
+#### Scenario: Invalid gains are rejected
+
+- **WHEN** an operator configures a negative `textGain` or `keywordMultiplier` override
+- **THEN** configuration validation rejects that value

--- a/openspec/changes/add-will-policy-channel-overrides/tasks.md
+++ b/openspec/changes/add-will-policy-channel-overrides/tasks.md
@@ -1,0 +1,13 @@
+## 1. Configuration and resolution
+
+- [x] 1.1 Add typed `channelOverrides` entries for `textGain` and `keywordMultiplier`.
+- [x] 1.2 Add a Koishi table schema with non-negative override values.
+- [x] 1.3 Resolve the first matching rule while creating each channel-scoped engine.
+- [x] 1.4 Normalize direct-message account IDs for `private:` channel IDs.
+
+## 2. Verification and documentation
+
+- [x] 2.1 Cover matching, fallback, ordering, and direct-message normalization.
+- [x] 2.2 Document configuration and compatibility behavior.
+- [x] 2.3 Run focused tests, type checking, and formatting.
+- [ ] 2.4 Run OpenSpec validation when the `openspec` CLI is available.

--- a/plugins/will-policy/README.md
+++ b/plugins/will-policy/README.md
@@ -67,7 +67,19 @@ plugins:
         - 代码
       keywordMultiplier: 1.8
       mentionForce: true
+
+      # 按频道覆盖基础增益和关键词乘数；第一条匹配规则生效
+      channelOverrides:
+        - platform: onebot
+          channelId: "123456789"  # 替换为实际的群号
+          isDirect: false
+          textGain: 1
+          keywordMultiplier: 1.2
 ```
+
+`channelOverrides` 只影响 `willingness` 引擎。`platform` 和 `channelId` 可以使用 `*` 作为通配值；`isDirect`
+留空时同时匹配群聊与私聊。匹配私聊时可直接填账号，插件会按 `private:<账号>` 匹配实际频道；也可显式填写完整的 `private:<账号>`。
+未匹配任何规则的频道继续使用全局 `textGain` 和 `keywordMultiplier`。
 
 ## 什么时候走哪套配置
 

--- a/plugins/will-policy/src/index.ts
+++ b/plugins/will-policy/src/index.ts
@@ -5,7 +5,7 @@ import type { ChannelContext, WillEngine } from "koishi-plugin-yesimbot";
 
 import { resolvePolicy } from "./policy.js";
 import { PolicyRoutingEngine } from "./routing.js";
-import type { WillPolicyConfig } from "./types.js";
+import type { PolicyWillingnessChannelOverride, PolicyWillingnessConfig, WillPolicyConfig } from "./types.js";
 import { PolicyWillingnessEngine } from "./willingness.js";
 
 export const WillPolicyConfigSchema: Schema<WillPolicyConfig> = Schema.intersect([
@@ -56,6 +56,18 @@ export const WillPolicyConfigSchema: Schema<WillPolicyConfig> = Schema.intersect
         mentionForce: Schema.boolean().default(false).description("被 @ 时强制触发"),
         quoteForce: Schema.boolean().default(false).description("引用时强制触发"),
         directForce: Schema.boolean().default(false).description("私聊强制触发"),
+        channelOverrides: Schema.array(
+          Schema.object({
+            platform: Schema.string().default("*").description("平台；* 表示任意平台"),
+            channelId: Schema.string().default("*").description("频道、群或私聊账号；* 表示任意"),
+            isDirect: Schema.boolean().description("是否私聊；留空同时匹配群聊与私聊"),
+            textGain: Schema.number().min(0).description("普通消息基础增益覆盖"),
+            keywordMultiplier: Schema.number().min(0).description("命中关键词时的乘数覆盖"),
+          }),
+        )
+          .role("table")
+          .default([])
+          .description("按顺序匹配的频道意愿值覆盖；第一条匹配规则生效"),
       })
         .required()
         .description("意愿值引擎配置；仅在 engine 为 willingness 时生效"),
@@ -159,12 +171,11 @@ export default class WillPolicyPlugin {
     return matched;
   }
 
-  public setup(_scope: ChannelContext): WillEngine {
+  public setup(scope: ChannelContext): WillEngine {
     const resolved = resolvePolicy(this.config);
     this.logger.debug("resolve_will_policy", { engine: resolved.engine, routing: resolved.routing, willingness: resolved.willingness });
-    return resolved.engine === "routing"
-      ? new PolicyRoutingEngine(resolved.routing, this.logger)
-      : new PolicyWillingnessEngine(resolved.willingness, this.logger);
+    if (resolved.engine === "routing") return new PolicyRoutingEngine(resolved.routing, this.logger);
+    return new PolicyWillingnessEngine(resolveWillingnessForChannel(resolved.willingness, scope), this.logger);
   }
 
   public async stop(): Promise<void> {
@@ -205,4 +216,26 @@ export default class WillPolicyPlugin {
   private instanceDescription(): string {
     return [`WillPolicy[${this.instanceId.slice(0, 8)}]`, `engine=${this.config.engine}`, `priority=${this.priority}`].join(" ");
   }
+}
+
+export function resolveWillingnessForChannel(config: PolicyWillingnessConfig, context: ChannelContext): PolicyWillingnessConfig {
+  const override = config.channelOverrides?.find((rule) => matchesChannelOverride(context, rule));
+  if (!override) return config;
+  return {
+    ...config,
+    ...(override.textGain === undefined ? {} : { textGain: override.textGain }),
+    ...(override.keywordMultiplier === undefined ? {} : { keywordMultiplier: override.keywordMultiplier }),
+  };
+}
+
+function matchesChannelOverride(context: ChannelContext, rule: PolicyWillingnessChannelOverride): boolean {
+  if (rule.platform !== "*" && rule.platform !== context.platform) return false;
+  const channelId = context.type === "direct" ? normalizeDirectChannelId(rule) : rule.channelId;
+  if (channelId !== "*" && channelId !== context.channelId) return false;
+  return rule.isDirect === undefined || rule.isDirect === (context.type === "direct");
+}
+
+function normalizeDirectChannelId(rule: PolicyWillingnessChannelOverride): string {
+  if (rule.isDirect !== false && rule.channelId !== "*" && !rule.channelId.startsWith("private:")) return `private:${rule.channelId}`;
+  return rule.channelId;
 }

--- a/plugins/will-policy/src/types.ts
+++ b/plugins/will-policy/src/types.ts
@@ -34,6 +34,15 @@ export interface PolicyWillingnessConfig {
   readonly mentionForce: boolean;
   readonly quoteForce: boolean;
   readonly directForce: boolean;
+  readonly channelOverrides?: PolicyWillingnessChannelOverride[];
+}
+
+export interface PolicyWillingnessChannelOverride {
+  readonly platform: string;
+  readonly channelId: string;
+  readonly isDirect?: boolean;
+  readonly textGain?: number;
+  readonly keywordMultiplier?: number;
 }
 
 export interface WillPolicyConfig {

--- a/plugins/will-policy/tests/plugin.test.ts
+++ b/plugins/will-policy/tests/plugin.test.ts
@@ -1,10 +1,10 @@
-import type { WillPlugin } from "koishi-plugin-yesimbot";
+import { createMessage, type WillPlugin } from "koishi-plugin-yesimbot";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("koishi", async () => import("@koishijs/core"));
 
-import WillPolicyPlugin from "../src/index.js";
-import { defaultRoutingConfig, defaultWillingnessConfig } from "../src/types.js";
+import WillPolicyPlugin, { resolveWillingnessForChannel } from "../src/index.js";
+import { defaultRoutingConfig, defaultWillingnessConfig, type PolicyWillingnessConfig } from "../src/types.js";
 
 interface CommandAction {
   (argv: { session?: { send: ReturnType<typeof vi.fn> } }): Promise<unknown>;
@@ -65,6 +65,95 @@ describe("WillPolicyPlugin", () => {
 
     expect(registered).toHaveLength(1);
     expect(plugin.match({} as never)).toBe(false);
+  });
+
+  it("applies the first matching channel willingness override", async () => {
+    const { plugin } = await createInstance(() => true);
+    const config: PolicyWillingnessConfig = {
+      ...plugin.config.willingness!,
+      channelOverrides: [
+        { platform: "test", channelId: "room-1", textGain: 1, keywordMultiplier: 2 },
+        { platform: "*", channelId: "*", textGain: 99 },
+      ],
+    };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "guild", platform: "test", channelId: "room-1", guildId: "room-1" });
+
+    expect(resolved.textGain).toBe(1);
+    expect(resolved.keywordMultiplier).toBe(2);
+  });
+
+  it("preserves omitted override fields from the global configuration", () => {
+    const config = { ...defaultWillingnessConfig(), keywordMultiplier: 7, channelOverrides: [{ platform: "test", channelId: "room-1", textGain: 2 }] };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "guild", platform: "test", channelId: "room-1", guildId: "room-1" });
+
+    expect(resolved.textGain).toBe(2);
+    expect(resolved.keywordMultiplier).toBe(7);
+  });
+
+  it("matches guild channels when isDirect is omitted", () => {
+    const config = { ...defaultWillingnessConfig(), channelOverrides: [{ platform: "test", channelId: "room-1", textGain: 4 }] };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "guild", platform: "test", channelId: "room-1", guildId: "room-1" });
+
+    expect(resolved.textGain).toBe(4);
+  });
+
+  it("matches wildcard platforms", () => {
+    const config = { ...defaultWillingnessConfig(), channelOverrides: [{ platform: "*", channelId: "room-1", textGain: 5 }] };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "guild", platform: "another-platform", channelId: "room-1", guildId: "room-1" });
+
+    expect(resolved.textGain).toBe(5);
+  });
+
+  it("keeps global willingness values when no channel override matches", async () => {
+    const config = { ...defaultWillingnessConfig(), channelOverrides: [{ platform: "test", channelId: "other-room", textGain: 1 }] };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "guild", platform: "test", channelId: "room-1", guildId: "room-1" });
+
+    expect(resolved.textGain).toBe(defaultWillingnessConfig().textGain);
+  });
+
+  it("normalizes direct account ids before matching overrides", async () => {
+    const config = { ...defaultWillingnessConfig(), channelOverrides: [{ platform: "test", channelId: "user-1", isDirect: true, textGain: 3 }] };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "direct", platform: "test", channelId: "private:user-1", selfId: "bot-1", userId: "user-1" });
+
+    expect(resolved.textGain).toBe(3);
+  });
+
+  it("normalizes direct account ids when isDirect is omitted", () => {
+    const config = { ...defaultWillingnessConfig(), channelOverrides: [{ platform: "test", channelId: "user-1", textGain: 6 }] };
+
+    const resolved = resolveWillingnessForChannel(config, { type: "direct", platform: "test", channelId: "private:user-1", selfId: "bot-1", userId: "user-1" });
+
+    expect(resolved.textGain).toBe(6);
+  });
+
+  it("applies channel overrides through plugin setup", async () => {
+    const { plugin } = await createInstance(() => true);
+    const configured = new WillPolicyPlugin(plugin.ctx, {
+      engine: "willingness",
+      willingness: { ...defaultWillingnessConfig(), channelOverrides: [{ platform: "test", channelId: "room-1", textGain: 8 }] },
+    });
+
+    const engine = configured.setup({ type: "guild", platform: "test", channelId: "room-1", guildId: "room-1" });
+    await engine.decide(
+      createMessage({
+        platform: "test",
+        selfId: "bot-1",
+        timestamp: Date.now(),
+        channel: { id: "room-1", type: 0 },
+        user: { id: "user-1" },
+        messageId: "m-1",
+        elements: [],
+      }),
+      { activeTurnId: null },
+    );
+
+    expect(engine.getCurrentWillingness?.()).toBe(8);
   });
 
   it("registers one root debug command for all cloned instances", async () => {


### PR DESCRIPTION
# 为 will-policy 插件优化：支持按频道覆盖意愿值参数

> 本 PR 专注于 **will-policy 插件**的增强：为意愿值（willingness）引擎增加按频道/按群覆盖能力，解决不同群消息活跃度差异导致的触发失衡问题（高活跃群过度触发、低活跃群难以触发）。

## 动机

当前 will-policy 的 willingness 参数（如 `textGain`、`keywordMultiplier`）对所有频道全局生效。实测中高活跃群（消息 400+ 条/小时）意愿值积累过快，触发回复频率过高；而低活跃群难以攒够阈值。不同群需要不同的活跃度参数。

## 改动内容

仅在 `plugins/will-policy` 内改动，**不涉及 Core 与其他插件**：

- **新增 `channelOverrides` 规则表**（willingness 配置内）：
  - 规则按 `platform` / `channelId` / 可选 `isDirect` 匹配频道（`*` 通配支持）
  - 每条规则可覆盖 `textGain` 与 `keywordMultiplier`，**未填写的字段保持全局值**
  - **按配置顺序第一条命中生效**，未匹配任何规则的频道保持全局配置
  - 私聊规则可直接填裸账号，匹配时自动规范化为 `private:<账号>`（与 quota 的 `quotaRules` 约定一致）
- 新增配置 Schema（`role("table")` 控制台表格编辑）、类型定义与文档
- 新增 7 个测试用例：匹配优先序、部分覆盖保持全局、isDirect 留空匹配群聊、platform 通配、无匹配回退全局、私聊 ID 规范化（含 isDirect 留空场景）、插件 setup 集成测试

## 兼容性

- `channelOverrides` 为可选配置（默认 `[]`），**不配置时行为与现状完全一致**
- `WillEngine` / `WillPlugin` 接口不变，Core 无需改动
- 覆盖在 `setup(ChannelContext)` 创建频道引擎时解析，不影响运行时决策路径

## 测试

`plugins/will-policy` 全部测试通过：**21 passed**（4 个测试文件）。

## 附

- 含 openspec 变更提案：`openspec/changes/add-will-policy-channel-overrides/`
- 若愿意采用 computed 配置（v3 风格函数式分群）也可以后续迭代，当前实现保持规则表形式与 v4 生态一致
