### PR TITLE
feat(schedule): 支持静默后台任务

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -92,8 +92,8 @@ splits blank-line prose.
 stations that merge untagged reasoning into message content. When enabled, the
 constitution requires all user-visible output inside `<reply>…</reply>`, and Core
 drops text outside complete wrapper regions before delivery while preserving the
-raw assistant output in history. If no complete wrapper is present, delivery
-falls back to the raw output so normal replies are not silently dropped.
+raw assistant output in history. If no complete wrapper is present, Core drops
+the entire output instead of risking delivery of untagged reasoning.
 
 ## Storage and records
 

--- a/core/README.md
+++ b/core/README.md
@@ -93,7 +93,9 @@ stations that merge untagged reasoning into message content. When enabled, the
 constitution requires all user-visible output inside `<reply>…</reply>`, and Core
 drops text outside complete wrapper regions before delivery while preserving the
 raw assistant output in history. If no complete wrapper is present, Core drops
-the entire output instead of risking delivery of untagged reasoning.
+the entire output instead of risking delivery of untagged reasoning, then feeds
+a format correction back into the active turn (or persists it for the next turn
+if the turn has already finished).
 
 ## Storage and records
 

--- a/core/src/messages/index.ts
+++ b/core/src/messages/index.ts
@@ -194,7 +194,7 @@ export function parseReply(raw: string, options: ParseReplyOptions = {}): Elemen
 function stripFinalReplyRegions(source: string, tagName: string | undefined): string {
   if (!tagName) return source;
   const matches = [...source.matchAll(new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tagName}\\s*>`, "gi"))];
-  if (matches.length === 0) return source;
+  if (matches.length === 0) return "";
   return matches.map((match) => match[1]).join("\n");
 }
 

--- a/core/src/messages/index.ts
+++ b/core/src/messages/index.ts
@@ -49,6 +49,11 @@ export interface ParseReplyOptions {
   readonly finalReplyTag?: string;
 }
 
+export interface ParsedReply {
+  readonly segments: Element[][];
+  readonly missingFinalReply: boolean;
+}
+
 declare module "@yesimbot/agent-runtime" {
   interface AgentCustomMessages {
     "yesimbot.event": Event;
@@ -132,6 +137,10 @@ export function formatElements(elements: readonly Element[]): string {
 }
 
 export function parseReply(raw: string, options: ParseReplyOptions = {}): Element[][] {
+  return parseReplyWithMetadata(raw, options).segments;
+}
+
+export function parseReplyWithMetadata(raw: string, options: ParseReplyOptions = {}): ParsedReply {
   const source = stripInnerThoughtRegions(raw.replaceAll(MARK, ""));
   const nonce = `${MARK}t${Math.random().toString(36).slice(2)}`;
   const captured: string[] = [];
@@ -151,7 +160,8 @@ export function parseReply(raw: string, options: ParseReplyOptions = {}): Elemen
     if (close < 0) break;
     cursor = close + 7;
   }
-  masked = stripFinalReplyRegions(masked, options.finalReplyTag);
+  const finalReply = extractFinalReplyRegions(masked, options.finalReplyTag);
+  masked = finalReply.content;
   const restore = (element: Element): Element[] => {
     if (element.type === "inner_thought") return [];
     if (element.type !== "text") return [h(element.type, element.attrs, element.children.flatMap(restore))];
@@ -188,14 +198,14 @@ export function parseReply(raw: string, options: ParseReplyOptions = {}): Elemen
     flush();
     return segments;
   };
-  return split(h.parse(masked).flatMap(restore));
+  return { segments: split(h.parse(masked).flatMap(restore)), missingFinalReply: finalReply.missing };
 }
 
-function stripFinalReplyRegions(source: string, tagName: string | undefined): string {
-  if (!tagName) return source;
+function extractFinalReplyRegions(source: string, tagName: string | undefined): { content: string; missing: boolean } {
+  if (!tagName) return { content: source, missing: false };
   const matches = [...source.matchAll(new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tagName}\\s*>`, "gi"))];
-  if (matches.length === 0) return "";
-  return matches.map((match) => match[1]).join("\n");
+  if (matches.length === 0) return { content: "", missing: true };
+  return { content: matches.map((match) => match[1]).join("\n"), missing: false };
 }
 
 function stripInnerThoughtRegions(source: string): string {

--- a/core/src/messengers/index.ts
+++ b/core/src/messengers/index.ts
@@ -68,7 +68,8 @@ export class Messenger {
     if (!bot) throw new Error(`No Bot is available for ${event.platform}:${event.selfId}`);
     const channel = await this.channels.resolve(contextFromRecord(event)!);
     const runtime = await this.runtimes.get(channel, bot);
-    const result = await runtime.post(event, options ?? { trigger: true, ifBusy: "defer" });
+    const postOptions = options ?? { trigger: true, ifBusy: "defer" };
+    const result = await runtime.post(event, postOptions);
     this.logger.debug("messenger.post", {
       eventType: event.eventType,
       platform: event.platform,
@@ -76,7 +77,10 @@ export class Messenger {
       result: result.kind,
       eventId: result.eventId,
     });
-    if (result.kind === "run") await this.track(this.deliverActive(bot, event.channel.id, runtime, result));
+    if (result.kind === "run") {
+      const delivery = postOptions.delivery === "silent" ? this.discardActive(runtime, result) : this.deliverActive(bot, event.channel.id, runtime, result);
+      await this.track(delivery);
+    }
   }
 
   public async stop(): Promise<void> {
@@ -146,6 +150,20 @@ export class Messenger {
         await this.failDelivery(runtime, result, delivery, cause);
       }
     });
+  }
+
+  private async discardActive(runtime: ChannelRuntime, result: RunResult): Promise<void> {
+    const delivery = emptyDeliveryContext(result.eventId);
+    try {
+      for await (const output of result.output) {
+        if (result.signal.aborted) return;
+        delivery.turnId = output.turnId;
+        delivery.messageId = output.messageId;
+        delivery.segmentTotal = output.segments.length;
+      }
+    } catch (cause) {
+      await this.failDelivery(runtime, result, delivery, cause);
+    }
   }
 
   private async *pacedSegments(result: RunResult, delivery: DeliveryContext): AsyncIterable<readonly Element[]> {

--- a/core/src/runtimes/channel.ts
+++ b/core/src/runtimes/channel.ts
@@ -21,7 +21,7 @@ import {
   createEvent,
   createMessage,
   formatInput,
-  parseReply,
+  parseReplyWithMetadata,
   isEvent,
   isMessage,
   isMessageRecord,
@@ -269,6 +269,7 @@ export class ChannelRuntime {
   ): Promise<void> {
     let assistant = false;
     let completed = false;
+    let finalReplyFeedbackInjected = false;
     let turnId = "";
     try {
       for await (const event of stream) {
@@ -307,8 +308,23 @@ export class ChannelRuntime {
           turnId = event.turnId;
           const content = renderAssistantText(event.message.content);
           if (content !== undefined) {
+            const finalReplyTag = this.options.config.wrapFinalReply ? FINAL_REPLY_TAG : undefined;
+            const parsed = parseReplyWithMetadata(content, { finalReplyTag });
+            if (parsed.missingFinalReply && !finalReplyFeedbackInjected) {
+              finalReplyFeedbackInjected = true;
+              try {
+                const feedback = createSystemMessage(
+                  `上一轮的回复因未使用必需的 <${FINAL_REPLY_TAG}>…</${FINAL_REPLY_TAG}> 格式而被拦截。下一轮如需向用户发送内容，必须将完整的最终回复放在且仅放在一个 <${FINAL_REPLY_TAG}>…</${FINAL_REPLY_TAG}> 中；内部思考和工具调用不要放入标签。`,
+                );
+                if (this.agent.getActiveTurnId() === event.turnId) this.agent.send(feedback, { ifBusy: "join" });
+                else await this.agent.append(feedback);
+                this.logger.debug("runtime.output.final_reply_feedback", { turnId, messageId: event.message.id });
+              } catch (cause) {
+                this.logger.warn("runtime.output.final_reply_feedback_failed", { turnId, messageId: event.message.id, cause });
+              }
+            }
             const segments = await prepareOutputSegments(
-              parseReply(content, { finalReplyTag: this.options.config.wrapFinalReply ? FINAL_REPLY_TAG : undefined }),
+              parsed.segments,
               this.options.channel.resources,
               controller.signal,
             );

--- a/core/src/runtimes/channel.ts
+++ b/core/src/runtimes/channel.ts
@@ -64,7 +64,11 @@ export type RuntimeResult =
   | { readonly kind: "join"; readonly eventId: string; readonly turnId: string }
   | { readonly kind: "run"; readonly eventId: string; readonly output: AsyncIterable<ChannelOutput>; readonly signal: AbortSignal };
 
-export type PostOptions = { readonly trigger?: boolean; readonly ifBusy?: "defer" | "join" | "reject" };
+export type PostOptions = {
+  readonly trigger?: boolean;
+  readonly ifBusy?: "defer" | "join" | "reject";
+  readonly delivery?: "channel" | "silent";
+};
 
 export interface ChannelRuntimeOptions {
   readonly channel: Channel;

--- a/core/tests/messages.test.ts
+++ b/core/tests/messages.test.ts
@@ -451,10 +451,9 @@ describe("parseReply", () => {
     expect(segments.map(text)).toEqual(["一", "二"]);
   });
 
-  it("keeps raw output unchanged when the final reply tag is missing", () => {
+  it("discards untagged output when the final reply tag is required", () => {
     const segments = parseReply("普通回复", { finalReplyTag: "reply" });
-    expect(segments).toHaveLength(1);
-    expect(text(segments[0])).toBe("普通回复");
+    expect(segments).toEqual([]);
   });
 
   it("does not treat a final reply tag inside a text container as a wrapper boundary", () => {

--- a/core/tests/messengers.test.ts
+++ b/core/tests/messengers.test.ts
@@ -64,6 +64,33 @@ describe("Messenger", () => {
     expect(runtime.fail).not.toHaveBeenCalled();
   });
 
+  it("runs a silent active post without delivering its output to the channel", async () => {
+    const ctx = new Context();
+    const bot = { platform: "test", selfId: "bot-1", sendMessage: vi.fn(async () => []) };
+    ctx.bots.push(bot as never);
+    const runtime = {
+      context: { type: "guild", platform: "test", channelId: "room-1", guildId: "room-1" },
+      fail: vi.fn(async () => undefined),
+      post: vi.fn(async () => ({
+        kind: "run" as const,
+        eventId: "event-1",
+        output: (async function* () {
+          yield { turnId: "turn-1", messageId: "assistant-1", segments: [[h.text("internal maintenance report")]] };
+        })(),
+        signal: new AbortController().signal,
+      })),
+    };
+    const channels = { resolve: vi.fn(async () => ({ context: runtime.context })) };
+    const runtimes = { get: vi.fn(async () => runtime) };
+    const messenger = new Messenger(ctx, config, channels as never, runtimes as never);
+
+    await messenger.post(event, { trigger: true, ifBusy: "defer", delivery: "silent" });
+
+    expect(runtime.post).toHaveBeenCalledWith(event, { trigger: true, ifBusy: "defer", delivery: "silent" });
+    expect(bot.sendMessage).not.toHaveBeenCalled();
+    expect(runtime.fail).not.toHaveBeenCalled();
+  });
+
   it("keeps the Session live through default translation and resource persistence", async () => {
     const ctx = new Context();
     const bot = { platform: "test", selfId: "bot-1", status: 1, sendMessage: vi.fn(async () => []) };

--- a/core/tests/runtimes.test.ts
+++ b/core/tests/runtimes.test.ts
@@ -63,7 +63,7 @@ const event = {
 // ChannelRuntime scheduling
 // ---------------------------------------------------------------------------
 
-async function runtime(providerTools?: ToolSet) {
+async function runtime(providerTools?: ToolSet, configOverrides: Partial<Config> = {}) {
   const root = await mkdtemp(join(tmpdir(), "yesimbot-runtime-"));
   const channel = new Channel({ type: "guild", platform: "test", channelId: "room", guildId: "room" }, root);
   await channel.conversation.init();
@@ -73,7 +73,7 @@ async function runtime(providerTools?: ToolSet) {
     will: { decide: state.decide, observe: state.observe } as never,
     model: {} as never,
     imageOutputSupported: false,
-    config,
+    config: { ...config, ...configOverrides },
     plugins: [],
     providerTools,
   });
@@ -172,8 +172,39 @@ describe("ChannelRuntime scheduling", () => {
           { turnId: "turn-1", messageId: "message-1", segments: [[expect.objectContaining({ type: "text", attrs: { content: "reply" } })]] },
         ]);
       }
+      expect(state.send).not.toHaveBeenCalled();
       expect(state.decide).not.toHaveBeenCalled();
       expect(state.run).toHaveBeenCalledOnce();
+    } finally {
+      await value.stop();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("re-prompts the active turn once after discarding unwrapped replies", async () => {
+    state.run.mockReturnValue(
+      (async function* () {
+        state.active = "turn-1";
+        yield { type: "message.appended", turnId: "turn-1", message: { role: "assistant", id: "message-1", content: "internal planning" } };
+        yield { type: "message.appended", turnId: "turn-1", message: { role: "assistant", id: "message-2", content: "still unwrapped" } };
+        yield { type: "message.appended", turnId: "turn-1", message: { role: "assistant", id: "message-3", content: "<reply>corrected reply</reply>" } };
+        state.active = null;
+      })(),
+    );
+    const { value, root } = await runtime(undefined, { wrapFinalReply: true });
+    try {
+      const result = await value.post(event);
+      expect(result.kind).toBe("run");
+      if (result.kind === "run") {
+        await expect(Array.fromAsync(result.output)).resolves.toEqual([
+          { turnId: "turn-1", messageId: "message-3", segments: [[expect.objectContaining({ type: "text", attrs: { content: "corrected reply" } })]] },
+        ]);
+      }
+      expect(state.send).toHaveBeenCalledOnce();
+      expect(state.send).toHaveBeenCalledWith(
+        expect.objectContaining({ role: "system", content: expect.stringMatching(/下一轮.*<reply>.*<\/reply>/s) }),
+        { ifBusy: "join" },
+      );
     } finally {
       await value.stop();
       await rm(root, { recursive: true, force: true });

--- a/plugins/schedule/src/scheduler.ts
+++ b/plugins/schedule/src/scheduler.ts
@@ -107,7 +107,7 @@ export class ScheduleScheduler {
   private async runTrigger(row: Schedule, occurrenceAt: string): Promise<void> {
     const event = buildDueEvent(row, occurrenceAt);
     try {
-      await this.ctx.yesimbot.messenger.post(event);
+      await this.ctx.yesimbot.messenger.post(event, { trigger: true, ifBusy: "defer", delivery: row.delivery });
       await this.store.finish(row.id, occurrenceAt, "accepted");
     } catch (cause) {
       const error = cause instanceof Error ? { name: cause.name, message: cause.message } : { name: "Error", message: String(cause) };

--- a/plugins/schedule/src/store.ts
+++ b/plugins/schedule/src/store.ts
@@ -23,6 +23,7 @@ const SCHEDULE_FIELDS = {
   channelId: "string",
   title: "string",
   prompt: "text",
+  delivery: { type: "string", initial: "channel" },
   kind: "string",
   at: { type: "string", nullable: true, initial: null },
   cron: { type: "string", nullable: true, initial: null },
@@ -65,6 +66,7 @@ export class ScheduleStore {
         channelId: scope.channelId,
         title: input.title,
         prompt: input.prompt,
+        delivery: input.delivery ?? "channel",
         kind: rule.kind,
         at: rule.kind === "once" ? rule.at : null,
         cron: rule.kind === "cron" ? rule.cron : null,
@@ -95,6 +97,7 @@ export class ScheduleStore {
       }
       const title = input.title ?? row.title;
       const prompt = input.prompt ?? row.prompt;
+      const delivery = input.delivery ?? row.delivery ?? "channel";
       if (title.length > MAX_TITLE_LENGTH) {
         throw new Error(`title must not exceed ${MAX_TITLE_LENGTH} characters`);
       }
@@ -120,8 +123,8 @@ export class ScheduleStore {
         if (row.state === "enabled") next = nextRunAt(rule, now);
       }
       const updatedAt = new Date(Date.now()).toISOString();
-      await this.model.set(SCHEDULE_TABLE, { ...scopeQuery(scope), id }, { title, prompt, kind, at, cron, nextRunAt: next, updatedAt });
-      return toSchedule({ ...row, title, prompt, kind, at, cron, nextRunAt: next, updatedAt });
+      await this.model.set(SCHEDULE_TABLE, { ...scopeQuery(scope), id }, { title, prompt, delivery, kind, at, cron, nextRunAt: next, updatedAt });
+      return toSchedule({ ...row, title, prompt, delivery, kind, at, cron, nextRunAt: next, updatedAt });
     });
   }
 
@@ -303,6 +306,7 @@ function toSchedule(row: ScheduleRow): Schedule {
     channelId: row.channelId,
     title: row.title,
     prompt: row.prompt,
+    delivery: row.delivery ?? "channel",
     state: row.state,
     nextRunAt: row.nextRunAt,
     lastResult: row.lastResult ?? undefined,

--- a/plugins/schedule/src/tools.ts
+++ b/plugins/schedule/src/tools.ts
@@ -8,6 +8,7 @@ const CREATE_SCHEMA = jsonSchema<CreateToolInput>({
   properties: {
     title: { type: "string", minLength: 1, maxLength: 120, description: "任务标题，最长 120 字符" },
     prompt: { type: "string", minLength: 1, maxLength: 2000, description: "到期时交给 Agent 的提示词，最长 2000 字符" },
+    delivery: { type: "string", enum: ["channel", "silent"], description: "输出方式：channel 发送到当前频道，silent 仅执行任务不发送消息" },
     at: { type: "string", format: "date-time", description: "一次性执行：一个未来的 RFC 3339 时刻，如 2030-01-01T08:00:00+08:00" },
     cron: { type: "string", description: "周期执行：Asia/Shanghai 时区的五段式 cron 表达式（分 时 日 月 周），相邻两次执行至少间隔 15 分钟" },
   },
@@ -27,6 +28,7 @@ const UPDATE_SCHEMA = jsonSchema<UpdateToolInput>({
     id: { type: "string", description: "要更新的定时任务 ID" },
     title: { type: "string", minLength: 1, maxLength: 120, description: "新标题，最长 120 字符" },
     prompt: { type: "string", minLength: 1, maxLength: 2000, description: "新提示词，最长 2000 字符" },
+    delivery: { type: "string", enum: ["channel", "silent"], description: "新的输出方式：channel 或 silent" },
     at: { type: "string", format: "date-time", description: "新的一次性执行时刻（RFC 3339，需在未来）" },
     cron: { type: "string", description: "新的五段式 cron 表达式（Asia/Shanghai，最小间隔 15 分钟）" },
   },
@@ -44,10 +46,10 @@ const ID_SCHEMA = jsonSchema<IdToolInput>({
 });
 
 /** Flat create input: title, prompt, and exactly one canonical rule form. */
-type CreateToolInput = { title: string; prompt: string } & ({ at: string; cron?: never } | { at?: never; cron: string });
+type CreateToolInput = { title: string; prompt: string; delivery?: "channel" | "silent" } & ({ at: string; cron?: never } | { at?: never; cron: string });
 
 /** Flat update input: id plus optional title/prompt and at most one rule form. */
-type UpdateToolInput = { id: string; title?: string; prompt?: string } & (
+type UpdateToolInput = { id: string; title?: string; prompt?: string; delivery?: "channel" | "silent" } & (
   | { at: string; cron?: never }
   | { at?: never; cron: string }
   | { at?: never; cron?: never }
@@ -74,20 +76,28 @@ export function createScheduleTools(scope: ScheduleScope, store: ScheduleStore, 
 }
 
 function toProjection(schedule: Schedule): ScheduleProjection {
-  return { id: schedule.id, title: schedule.title, kind: schedule.kind, state: schedule.state, nextRunAt: schedule.nextRunAt, lastResult: schedule.lastResult };
+  return {
+    id: schedule.id,
+    title: schedule.title,
+    delivery: schedule.delivery,
+    kind: schedule.kind,
+    state: schedule.state,
+    nextRunAt: schedule.nextRunAt,
+    lastResult: schedule.lastResult,
+  };
 }
 
 function createTool(scope: ScheduleScope, store: ScheduleStore, rearm: (() => Promise<void>) | undefined): AgentTool<CreateToolInput, ScheduleProjection> {
   return {
     name: "schedule_create",
     description:
-      "在当前频道创建一个定时任务：at（一次性执行）或 cron（周期执行）二选一。时间统一按 Asia/Shanghai 解释；at 使用 RFC 3339 时刻，cron 使用五段式表达式。",
+      "在当前频道创建一个定时任务：at（一次性执行）或 cron（周期执行）二选一。delivery 可选 channel（默认，发送结果）或 silent（仅执行任务，不发送消息）。时间统一按 Asia/Shanghai 解释；at 使用 RFC 3339 时刻，cron 使用五段式表达式。",
     inputSchema: CREATE_SCHEMA,
     execute: async (input) => {
       const createInput: ScheduleCreateInput =
         input.at !== undefined
-          ? { title: input.title, prompt: input.prompt, kind: "once", at: input.at }
-          : { title: input.title, prompt: input.prompt, kind: "cron", cron: input.cron };
+          ? { title: input.title, prompt: input.prompt, delivery: input.delivery, kind: "once", at: input.at }
+          : { title: input.title, prompt: input.prompt, delivery: input.delivery, kind: "cron", cron: input.cron };
       const schedule = await store.create(scope, createInput);
       await rearm?.();
       return toProjection(schedule);
@@ -98,7 +108,7 @@ function createTool(scope: ScheduleScope, store: ScheduleStore, rearm: (() => Pr
 function listTool(scope: ScheduleScope, store: ScheduleStore): AgentTool<Record<string, never>, ScheduleProjection[]> {
   return {
     name: "schedule_list",
-    description: "列出当前频道的全部定时任务，返回每个任务的紧凑信息：id、标题、类型（once/cron）、状态、下次执行时间和最近结果。",
+    description: "列出当前频道的全部定时任务，返回每个任务的紧凑信息：id、标题、输出方式、类型（once/cron）、状态、下次执行时间和最近结果。",
     inputSchema: LIST_SCHEMA,
     execute: async () => (await store.list(scope)).map(toProjection),
   };
@@ -107,14 +117,15 @@ function listTool(scope: ScheduleScope, store: ScheduleStore): AgentTool<Record<
 function updateTool(scope: ScheduleScope, store: ScheduleStore, rearm: (() => Promise<void>) | undefined): AgentTool<UpdateToolInput, ScheduleProjection> {
   return {
     name: "schedule_update",
-    description: "更新当前频道一个定时任务的标题、提示词或执行规则。规则替换时 at 与 cron 至多提供一个；未提供的字段保持不变。",
+    description: "更新当前频道一个定时任务的标题、提示词、输出方式或执行规则。规则替换时 at 与 cron 至多提供一个；未提供的字段保持不变。",
     inputSchema: UPDATE_SCHEMA,
-    execute: async ({ id, title, prompt, at, cron }) => {
+    execute: async ({ id, title, prompt, delivery, at, cron }) => {
       let patch: ScheduleUpdateInput = {};
       if (at !== undefined) patch = { kind: "once", at };
       else if (cron !== undefined) patch = { kind: "cron", cron };
       if (title !== undefined) patch = { ...patch, title };
       if (prompt !== undefined) patch = { ...patch, prompt };
+      if (delivery !== undefined) patch = { ...patch, delivery };
       const schedule = await store.update(scope, id, patch);
       await rearm?.();
       return toProjection(schedule);

--- a/plugins/schedule/src/types.ts
+++ b/plugins/schedule/src/types.ts
@@ -1,4 +1,5 @@
 export type ScheduleState = "enabled" | "paused" | "cancelled" | "completed";
+export type ScheduleDelivery = "channel" | "silent";
 
 export type ScheduleLastResult = {
   occurrenceAt: string;
@@ -15,6 +16,7 @@ export type Schedule = {
   channelId: string;
   title: string;
   prompt: string;
+  delivery: ScheduleDelivery;
   state: ScheduleState;
   /** Null while the schedule is paused, cancelled, or completed. */
   nextRunAt: string | null;
@@ -23,9 +25,12 @@ export type Schedule = {
   updatedAt: string;
 } & ({ kind: "once"; at: string; cron?: never } | { kind: "cron"; cron: string; at?: never });
 
-export type ScheduleCreateInput = { title: string; prompt: string } & ({ kind: "once"; at: string; cron?: never } | { kind: "cron"; cron: string; at?: never });
+export type ScheduleCreateInput = { title: string; prompt: string; delivery?: ScheduleDelivery } & (
+  | { kind: "once"; at: string; cron?: never }
+  | { kind: "cron"; cron: string; at?: never }
+);
 
-export type ScheduleUpdateInput = { title?: string; prompt?: string } & (
+export type ScheduleUpdateInput = { title?: string; prompt?: string; delivery?: ScheduleDelivery } & (
   | { kind?: "once"; at?: string; cron?: never }
   | { kind?: "cron"; cron?: string; at?: never }
 );
@@ -38,6 +43,7 @@ export type ScheduleUpdateInput = { title?: string; prompt?: string } & (
 export type ScheduleProjection = {
   id: string;
   title: string;
+  delivery: ScheduleDelivery;
   kind: "once" | "cron";
   state: ScheduleState;
   nextRunAt: string | null;
@@ -57,6 +63,7 @@ export type ScheduleRow = {
   channelId: string;
   title: string;
   prompt: string;
+  delivery: ScheduleDelivery;
   kind: "once" | "cron";
   at: string | null;
   cron: string | null;

--- a/plugins/schedule/tests/proactive.integration.test.ts
+++ b/plugins/schedule/tests/proactive.integration.test.ts
@@ -233,6 +233,7 @@ describe("Schedule proactive trigger integration", () => {
     expect(fixture.trigger).toHaveBeenCalledTimes(1);
     expect(fixture.trigger).toHaveBeenCalledWith(
       expect.objectContaining({ eventType: "schedule.due", platform: "test", selfId: "bot-1", channel: { id: "room-1", type: Universal.Channel.Type.TEXT } }),
+      { trigger: true, ifBusy: "defer", delivery: "channel" },
     );
     const event = fixture.trigger.mock.calls[0][0] as EventRecord<"schedule.due">;
     expect(event).toMatchObject({

--- a/plugins/schedule/tests/scheduler.test.ts
+++ b/plugins/schedule/tests/scheduler.test.ts
@@ -195,11 +195,24 @@ describe("ScheduleScheduler", () => {
       schedule: { id: created.id, title: "standup", kind: "once", scheduledFor: T0 },
     });
     expect(event.timestamp).toBe(Date.parse(T0));
+    expect(trigger.mock.calls[0][1]).toEqual({ trigger: true, ifBusy: "defer", delivery: "channel" });
 
     const [updated] = await store.list(sharedScope);
     expect(updated.state).toBe("completed");
     expect(updated.nextRunAt).toBeNull();
     expect(updated.lastResult).toMatchObject({ occurrenceAt: T0, status: "accepted" });
+  });
+
+  it("runs a silent schedule without channel delivery", async () => {
+    vi.setSystemTime(new Date(Date.parse(T0) - 3_600_000));
+    await store.create(sharedScope, { title: "memory maintenance", prompt: "Update memory without replying.", delivery: "silent", kind: "once", at: T0 });
+
+    vi.setSystemTime(new Date(T0));
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(trigger).toHaveBeenCalledTimes(1);
+    expect(trigger.mock.calls[0][1]).toEqual({ trigger: true, ifBusy: "defer", delivery: "silent" });
   });
 
   it("submits consecutive cron occurrences without overlap", async () => {

--- a/plugins/schedule/tests/store.test.ts
+++ b/plugins/schedule/tests/store.test.ts
@@ -180,6 +180,7 @@ describe("ScheduleStore", () => {
       channelId: "room-1",
       title: "Standup",
       prompt: "Prepare the daily standup.",
+      delivery: "channel",
       kind: "once",
       at: FUTURE,
       state: "enabled",
@@ -187,6 +188,23 @@ describe("ScheduleStore", () => {
     });
     expect(schedule.id).toBeDefined();
     expect(schedule.lastResult).toBeUndefined();
+  });
+
+  it("persists and updates silent delivery without changing the schedule rule", async () => {
+    const created = await store.create(sharedScope, {
+      title: "Memory maintenance",
+      prompt: "Update memory without replying.",
+      delivery: "silent",
+      kind: "once",
+      at: FUTURE,
+    });
+    expect(created.delivery).toBe("silent");
+
+    const updated = await store.update(sharedScope, created.id, { delivery: "channel" });
+    expect(updated.delivery).toBe("channel");
+    expect(updated.kind).toBe("once");
+    expect(updated.at).toBe(FUTURE);
+    expect(updated.nextRunAt).toBe(FUTURE);
   });
 
   it("rejects a cron interval below the 15-minute limit", async () => {

--- a/plugins/schedule/tests/tools.test.ts
+++ b/plugins/schedule/tests/tools.test.ts
@@ -31,6 +31,7 @@ function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
     channelId: "room-1",
     title: "Standup",
     prompt: "Run the daily standup.",
+    delivery: "channel",
     kind: "once",
     at: "2030-01-01T00:00:00.000Z",
     state: "enabled",
@@ -65,6 +66,8 @@ describe("schedule agent tools", () => {
     const validate = ajv.compile(schemaOf(createTool));
     expect(validate({ title: "Standup", prompt: "Run it.", at: "2030-01-01T00:00:00Z" })).toBe(true);
     expect(validate({ title: "Standup", prompt: "Run it.", cron: "0 9 * * 1" })).toBe(true);
+    expect(validate({ title: "Standup", prompt: "Run it.", delivery: "silent", cron: "0 9 * * 1" })).toBe(true);
+    expect(validate({ title: "Standup", prompt: "Run it.", delivery: "unknown", cron: "0 9 * * 1" })).toBe(false);
     expect(validate({ title: "Standup", prompt: "Run it." })).toBe(false);
     expect(validate({ title: "Standup", prompt: "Run it.", at: "2030-01-01T00:00:00Z", cron: "0 9 * * 1" })).toBe(false);
     expect(validate({ title: "Standup", prompt: "Run it.", at: "2030-01-01T00:00:00Z", channelId: "room-1" })).toBe(false);
@@ -80,6 +83,8 @@ describe("schedule agent tools", () => {
     expect(validate({ id: "s-1", at: "2030-01-01T00:00:00Z" })).toBe(true);
     expect(validate({ id: "s-1", cron: "0 9 * * 1" })).toBe(true);
     expect(validate({ id: "s-1", title: "New", cron: "0 9 * * 1" })).toBe(true);
+    expect(validate({ id: "s-1", delivery: "silent" })).toBe(true);
+    expect(validate({ id: "s-1", delivery: "unknown" })).toBe(false);
     expect(validate({ id: "s-1", at: "2030-01-01T00:00:00Z", cron: "0 9 * * 1" })).toBe(false);
     expect(validate({ id: "s-1", channelId: "room-1" })).toBe(false);
     expect(validate({ id: "s-1", at: "2030-01-01T00:00:00Z", platform: "onebot" })).toBe(false);
@@ -107,7 +112,7 @@ describe("schedule agent tools", () => {
     const [createTool] = createTools(store);
     const result = await execute(createTool, { title: "Standup", prompt: "Run the daily standup.", at: "2030-01-01T00:00:00.000Z" });
     expect(store.create).toHaveBeenCalledWith(scope, { title: "Standup", prompt: "Run the daily standup.", kind: "once", at: "2030-01-01T00:00:00.000Z" });
-    expect(result).toEqual({ id: "s-1", title: "Standup", kind: "once", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
+    expect(result).toEqual({ id: "s-1", title: "Standup", delivery: "channel", kind: "once", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
   });
 
   it("create maps a cron input to a recurring schedule", async () => {
@@ -116,7 +121,27 @@ describe("schedule agent tools", () => {
     const [createTool] = createTools(store);
     const result = await execute(createTool, { title: "Standup", prompt: "Run the daily standup.", cron: "0 9 * * 1" });
     expect(store.create).toHaveBeenCalledWith(scope, { title: "Standup", prompt: "Run the daily standup.", kind: "cron", cron: "0 9 * * 1" });
-    expect(result).toEqual({ id: "s-1", title: "Standup", kind: "cron", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
+    expect(result).toEqual({ id: "s-1", title: "Standup", delivery: "channel", kind: "cron", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
+  });
+
+  it("create persists silent delivery and exposes it in the projection", async () => {
+    const store = createStoreDouble();
+    store.create.mockResolvedValue(makeSchedule({ delivery: "silent" }));
+    const [createTool] = createTools(store);
+    const result = await execute(createTool, {
+      title: "Memory maintenance",
+      prompt: "Update memory without replying.",
+      delivery: "silent",
+      cron: "0 0 * * *",
+    });
+    expect(store.create).toHaveBeenCalledWith(scope, {
+      title: "Memory maintenance",
+      prompt: "Update memory without replying.",
+      delivery: "silent",
+      kind: "cron",
+      cron: "0 0 * * *",
+    });
+    expect(result).toMatchObject({ id: "s-1", delivery: "silent" });
   });
 
   it("list returns compact projections for the captured scope", async () => {
@@ -136,10 +161,11 @@ describe("schedule agent tools", () => {
     const result = (await execute(listTool, {})) as ScheduleProjection[];
     expect(store.list).toHaveBeenCalledWith(scope);
     expect(result).toEqual([
-      { id: "s-1", title: "Standup", kind: "once", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" },
+      { id: "s-1", title: "Standup", delivery: "channel", kind: "once", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" },
       {
         id: "s-2",
         title: "Digest",
+        delivery: "channel",
         kind: "cron",
         state: "enabled",
         nextRunAt: "2030-01-02T00:00:00.000Z",
@@ -154,7 +180,7 @@ describe("schedule agent tools", () => {
     const [, , updateTool] = createTools(store);
     const result = await execute(updateTool, { id: "s-1", title: "New title" });
     expect(store.update).toHaveBeenCalledWith(scope, "s-1", { title: "New title" });
-    expect(result).toEqual({ id: "s-1", title: "New title", kind: "once", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
+    expect(result).toEqual({ id: "s-1", title: "New title", delivery: "channel", kind: "once", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
   });
 
   it("update routes a cron rule replacement through the captured scope", async () => {
@@ -163,7 +189,16 @@ describe("schedule agent tools", () => {
     const [, , updateTool] = createTools(store);
     const result = await execute(updateTool, { id: "s-1", cron: "0 9 * * 1" });
     expect(store.update).toHaveBeenCalledWith(scope, "s-1", { kind: "cron", cron: "0 9 * * 1" });
-    expect(result).toEqual({ id: "s-1", title: "Standup", kind: "cron", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
+    expect(result).toEqual({ id: "s-1", title: "Standup", delivery: "channel", kind: "cron", state: "enabled", nextRunAt: "2030-01-01T00:00:00.000Z" });
+  });
+
+  it("update changes delivery without replacing the schedule rule", async () => {
+    const store = createStoreDouble();
+    store.update.mockResolvedValue(makeSchedule({ delivery: "silent" }));
+    const [, , updateTool] = createTools(store);
+    const result = await execute(updateTool, { id: "s-1", delivery: "silent" });
+    expect(store.update).toHaveBeenCalledWith(scope, "s-1", { delivery: "silent" });
+    expect(result).toMatchObject({ id: "s-1", delivery: "silent" });
   });
 
   it.each([
@@ -177,6 +212,6 @@ describe("schedule agent tools", () => {
     const tool = tools.find((candidate) => candidate.name === name)!;
     const result = await execute(tool, { id: "s-1" });
     expect(store[method]).toHaveBeenCalledWith(scope, "s-1");
-    expect(result).toEqual({ id: "s-1", title: "Standup", kind: "once", state, nextRunAt: "2030-01-01T00:00:00.000Z" });
+    expect(result).toEqual({ id: "s-1", title: "Standup", delivery: "channel", kind: "once", state, nextRunAt: "2030-01-01T00:00:00.000Z" });
   });
 });


### PR DESCRIPTION
## 问题

定时记忆整理任务会像普通频道消息一样投递模型输出。当模型在调用 `add_message` / `finish` 的同时输出规划文本，且 `wrapFinalReply` 已启用但没有生成 `<reply>` 包裹时，core 会回退发送原始文本，导致内部整理过程泄漏到群聊。

## 修改

- `wrapFinalReply` 改为 fail-closed：配置了 final reply 标签但输出没有完整包裹时，丢弃未包裹文本。
- schedule 新增逐任务 `delivery: "channel" | "silent"`。
- `silent` 模式仍完整执行模型与工具调用，但只排空输出，不向频道发送消息；投递异常仍按原路径记录。
- 既有任务和新任务默认保持 `channel`，兼容当前行为。
- create/update/list 工具与持久化模型均支持 `delivery`。

## 验证

- core 定向测试：50 passed
- schedule 全量测试：73 passed
- core / schedule typecheck：通过
- `git diff --check`：通过

已在实际 Koishi 实例部署验证：数据库迁移成功，schedule 插件正常启动，原任务保持 enabled 且 nextRunAt 不变，切换为 silent 后可持久化并在重启后正确读取。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 定时任务新增“频道投递”和“静默投递”选项，支持创建、更新及结果查看。
  - 静默投递会执行任务并记录结果，但不会向频道发送消息。
- **改进**
  - 启用最终回复包装时，未包含完整标签的模型输出将被丢弃，并触发格式纠正提示。
  - 定时任务触发时会正确应用投递方式。
- **测试**
  - 增加静默投递、定时任务配置及格式纠正流程的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->